### PR TITLE
WIP/ENH: Make S3File iterable, readline

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -687,6 +687,9 @@ class S3File(object):
                 self.s3.s3.put_object(Bucket=self.bucket, Key=self.key)
             self.s3._ls(self.bucket, refresh=True)
 
+    def __iter__(self):
+        return self
+
     def __del__(self):
         self.close()
 

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -503,6 +503,7 @@ class S3File(object):
         self.start = None
         self.end = None
         self.closed = False
+        self._mode = mode
         if mode == 'wb':
             self.buffer = io.BytesIO()
             self.parts = []
@@ -519,6 +520,18 @@ class S3File(object):
                 self.size = self.info()['Size']
             except ClientError:
                 raise IOError("File not accessible", path)
+
+    def readable(self):
+        '''Return whether the S3File was opened for reading'''
+        return self.mode == 'rb'
+
+    def seekable(self):
+        '''Return whether the S3File is seekable (only in read mode)'''
+        return self.readable()
+
+    def writable(self):
+        '''Return whether the S3File was opened for writing'''
+        return self.mode == 'wb'
 
     def info(self):
         """ File information about this path """

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -499,3 +499,26 @@ def test_write_blocks(s3):
         f.write(b'a' * 15*2**20)
         assert f.buffer.tell() == 0
     assert s3.info(test_bucket_name+'/temp')['Size'] == 15*2**20
+
+
+def test_readable(s3):
+    with s3.open(a, 'wb') as f:
+        assert not f.readable()
+
+    with s3.open(a, 'rb') as f:
+        assert f.readable()
+
+
+def test_seekable(s3):
+    with s3.open(a, 'wb') as f:
+        assert not f.seekable()
+
+    with s3.open(a, 'rb') as f:
+        assert f.seekable()
+
+def test_writable(s3):
+    with s3.open(a, 'wb') as f:
+        assert f.writable()
+
+    with s3.open(a, 'rb') as f:
+        assert not f.writable()

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -148,6 +148,13 @@ def test_readline_empty(s3):
         out = f.readline()
         assert out == b''
 
+def test_iterable(s3):
+    data = b'abc\n123'
+    with s3.open(a, 'wb') as f:
+        f.write(data)
+    with s3.open(a) as f, io.BytesIO(data) as g:
+        for froms3, fromio in zip(f, g):
+            assert froms3 == fromio
 
 def test_tokenize():
     from s3fs.core import tokenize

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -131,22 +131,31 @@ def test_readline_empty(s3):
     with s3.open(a, 'wb') as f:
         f.write(data)
     with s3.open(a, 'rb') as f:
-        result = r.readline()
+        result = f.readline()
         assert result == data
+
+def test_readline_blocksize(s3):
+    data = b'ab\n' + b'a' * (10 * 2**20) + b'\nab'
+    with s3.open(a, 'wb') as f:
+        f.write(data)
+    with s3.open(a, 'rb') as f:
+        result = f.readline()
+        expected = b'ab\n'
+        assert result == expected
+
+        result = f.readline()
+        expected = b'a' * (10 * 2**20) + b'\n'
+        assert result == expected
+
+        result = f.readline()
+        expected = b'ab'
+
 
 def test_next(s3):
     expected = csv_files['2014-01-01.csv'].split(b'\n')[0] + b'\n'
     with s3.open(test_bucket_name + '/2014-01-01.csv') as f:
         result = next(f)
         assert result == expected
-
-def test_readline_empty(s3):
-    data = b''
-    with s3.open(a, 'wb') as f:
-        f.write(data)
-    with s3.open(a, 'rb') as f:
-        out = f.readline()
-        assert out == b''
 
 def test_iterable(s3):
     data = b'abc\n123'


### PR DESCRIPTION
Adds a `readline` method to S3File, which is used to make them
iterable via py2 style `.next` and py3 style `__next__` methods.