### PR TITLE
Append wretry merge

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -549,7 +549,7 @@ class S3File(object):
         '''
         Read and return a line from the stream.
         
-        If size is specified, at most size bytes will be read.
+        If length is specified, at most size bytes will be read.
         '''  
         self._fetch(self.loc, self.loc+1)
         while True:

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -356,9 +356,17 @@ class S3FileSystem(object):
         self.rm(path1)
 
     def merge(self, path, filelist):
-        """ Create single file from list of files
+        """ Create single S3 file from list of S3 files
 
-        Uses multi-part, no data is downloaded.
+        Uses multi-part, no data is downloaded. The original files are
+        not deleted.
+
+        Parameters
+        ----------
+        path : str
+            The final file to produce
+        filelist : list of str
+            The paths, in order, to assemble into the final file.
         """
         bucket, key = split_path(path)
         mpu = self.s3.create_multipart_upload(Bucket=bucket, Key=key)
@@ -688,7 +696,7 @@ class S3File(object):
                     break
                 except S3_RETRYABLE_ERRORS:
                     if i < retries:
-                        logger.debug('Exception %e on S3 download, retrying',
+                        logger.debug('Exception %e on S3 upload, retrying',
                                      exc_info=True)
                         i += 1
                         continue

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -306,9 +306,6 @@ def test_errors(s3):
     with pytest.raises(IOError):
         s3.rm('unknown')
 
-    with pytest.raises(NotImplementedError):
-        s3.open('anyfile', 'ab')
-
     with pytest.raises(ValueError):
         with s3.open(test_bucket_name+'/temp', 'wb') as f:
             f.read()
@@ -531,3 +528,39 @@ def test_writable(s3):
     with s3.open(a, 'rb') as f:
         assert not f.writable()
 
+
+def test_merge(s3):
+    with s3.open(a, 'wb') as f:
+        f.write(b'a' * 10*2**20)
+        
+    with s3.open(b, 'wb') as f:
+        f.write(b'a' * 10*2**20)
+    s3.merge(test_bucket_name+'/joined', [a, b])
+    assert s3.info(test_bucket_name+'/joined')['Size'] == 2*10*2**20
+
+
+def test_append(s3):
+    data = text_files['nested/file1']
+    with s3.open(test_bucket_name+'/nested/file1', 'ab') as f:
+        assert f.tell() == len(data) # append, no write, small file
+    assert s3.cat(test_bucket_name+'/nested/file1') == data
+    with s3.open(test_bucket_name+'/nested/file1', 'ab') as f:
+        f.write(b'extra')  # append, write, small file
+    assert  s3.cat(test_bucket_name+'/nested/file1') == data+b'extra'
+
+    with s3.open(a, 'wb') as f:
+        f.write(b'a' * 10*2**20)
+    with s3.open(a, 'ab') as f:
+        pass # append, no write, big file
+    assert s3.cat(a) == b'a' * 10*2**20
+    
+    with s3.open(a, 'ab') as f:
+        f.write(b'extra') # append, small write, big file
+    assert s3.cat(a) == b'a' * 10*2**20 + b'extra'
+
+    with s3.open(a, 'ab') as f:
+        assert f.tell() == 10*2**20 + 5
+        f.write(b'b' * 10*2**20) # append, big write, big file
+        assert f.tell() == 20*2**20 + 5
+    assert s3.cat(a) == b'a' * 10*2**20 + b'extra' + b'b' *10*2**20
+    


### PR DESCRIPTION
Adds retries on write: raises after 10 tries by default. Recommend to catch that, and truncate at that point (self f.buffer to empty io.BytestIO, and call close()), could be done automatically.

Marge does multi-part copying on the server side, to allow splitting of big file and parallel upload.

Append mode either makes first chunk be the existing file (if size>=5MB) or downloads existing data if small. This means that the original file will *briefly* not exist.