### PR TITLE
REF: Use `head_object` for .info

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -8,7 +8,7 @@ from hashlib import md5
 import boto3
 import boto3.compat
 import boto3.s3.transfer as trans
-from botocore.exceptions import ClientError
+from botocore.exceptions import ClientError, ParamValidationError
 from botocore.client import Config
 
 from .utils import read_block
@@ -232,12 +232,14 @@ class S3FileSystem(object):
         if path.startswith('s3://'):
             path = path[len('s3://'):]
         path = path.rstrip('/')
-        files = self._ls(path)
-        files = [f for f in files if f['Key'].rstrip('/') == path]
-        if len(files) == 1:
-            return files[0]
-        else:
-            raise IOError("File not found: %s" %path)
+        bucket, key = split_path(path)
+        try:
+            info = self.s3.head_object(Bucket=bucket, Key=key)
+            info['Size'] = info['ContentLength']
+            info['Key'] = '/'.join([bucket, key])
+            return info
+        except (ClientError, ParamValidationError):
+            raise IOError("File not found: %s" % path)
 
     def walk(self, path):
         """ Return all entries below path """


### PR DESCRIPTION
This should be more efficient for `.info` calls.
The response dict is almost the same. They use `ContentLength` instead
of `Size` and don't include the key in the response.

One question I had was on exception handling. To get the test suite to
pass, I had to catch botocore's `ParamvalidationError.` Otherwise things
like `s3.open('x', 'rb')` failed with a ParamvalidationError, since `'x'`
isn't a valid bucket name, while the tests were expecting an IOError or
OSError. Would be curious to hear what you think on this.

This change was necessary to make the pandas test-suite pass. We had issues in the
past where a users's bucket allowed them to list some, but not all the items in a bucket.
The old implementation for `.info` did an `ls` on the bucket, and then filtered down to
the single file matching the key.
With this the pandas test-suite pretty much passes.
My changes are
[here](https://github.com/pydata/pandas/commit/e89e54a32e3b53764005da488215dd529b20ea6c)
Just a couple tests to fix up that were expecting different error
messages.

http://boto3.readthedocs.org/en/latest/reference/services/s3.html#S3.Client.head_object