### PR TITLE
Direct info

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -610,7 +610,9 @@ class S3File(object):
 
     def info(self):
         """ File information about this path """
-        return self.s3.info(self.path)
+        info = self.s3.s3.head_object(Bucket=self.bucket, Key=self.key)
+        info['Size'] = info.get('ContentLength')
+        return info
 
     def tell(self):
         """ Current file location """

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -9,7 +9,7 @@ from contextlib import contextmanager
 import boto3
 import boto3.compat
 import boto3.s3.transfer as trans
-from botocore.exceptions import ClientError
+from botocore.exceptions import ClientError, ParamValidationError
 from botocore.client import Config
 
 from .utils import read_block
@@ -415,7 +415,7 @@ class S3FileSystem(object):
         try:
             self.s3.copy_object(Bucket=buc2, Key=key2,
                                 CopySource='/'.join([buc1, key1]))
-        except ClientError:
+        except (ClientError, ParamValidationError):
             raise IOError('Copy failed', (path1, path2))
         self._ls(path2, refresh=True)
 
@@ -469,7 +469,7 @@ class S3FileSystem(object):
             try:
                 self.s3.create_bucket(Bucket=bucket)
                 self._ls("", refresh=True)
-            except ClientError:
+            except (ClientError, ParamValidationError):
                 raise IOError('Bucket create failed', path)
 
     def read_block(self, fn, offset, length, delimiter=None):
@@ -588,7 +588,7 @@ class S3File(object):
                 raise ValueError('Block size must be >=5MB')
             try:
                 self.mpu = s3.s3.create_multipart_upload(Bucket=bucket, Key=key)
-            except ClientError:
+            except (ClientError, ParamValidationError):
                 raise IOError('Open for write failed', path)
             self.forced = False
             if mode == 'ab' and s3.exists(path):
@@ -605,7 +605,7 @@ class S3File(object):
         else:
             try:
                 self.size = self.info()['Size']
-            except ClientError:
+            except (ClientError, ParamValidationError):
                 raise IOError("File not accessible", path)
 
     def info(self):

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -316,9 +316,6 @@ def test_errors(s3):
     with pytest.raises((IOError, OSError)):
         s3.mv(test_bucket_name+'/tmp/test/shfoshf/x', 'tmp/test/shfoshf/y')
 
-    #with pytest.raises((IOError, OSError)):
-    #    s3.open('x', 'wb')
-
     with pytest.raises((IOError, OSError)):
         s3.open('x', 'rb')
 
@@ -333,6 +330,9 @@ def test_errors(s3):
         f = s3.open(test_bucket_name+'/temp', 'rb')
         f.close()
         f.read()
+
+    with pytest.raises((IOError, OSError)):
+        s3.mkdir('/')
 
 
 def test_read_small(s3):


### PR DESCRIPTION
Fixes for pandas interoperability

- `S3File.info()` to call client.head_object rather than going through S3FileSystem's info, which calls client.list_objects; 
the latter will fail if some keys cannot be accessed. Thus, can still open files where we know the key beforehand. This
means that the two `info()` methods do not do wuite the same thing.
- add checks for ParamValidationError, which can occur (instead of ClientError) for illegal bucket names