### PR TITLE
Invalidate rather than update cache

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -185,16 +185,6 @@ class S3FileSystem(object):
         return {'key': cred['AccessKeyId'], 'secret': cred['SecretAccessKey'],
                 'token': cred['SessionToken'], 'anon': False}
 
-    def refresh_off(self):
-        """ Block auto-refresh when writing.
-
-        Use in conjunction with `refresh_on()` when writing many files to S3.
-        """
-        self.no_refresh = True
-
-    def refresh_on(self):
-        self.no_refresh = False
-
     def __getstate__(self):
         d = self.__dict__.copy()
         del d['s3']
@@ -447,7 +437,6 @@ class S3FileSystem(object):
                     UploadId=mpu['UploadId'], MultipartUpload=part_info)
         self.invalidate_cache(bucket)
 
-
     def copy(self, path1, path2):
         """ Copy file between locations on S3 """
         buc1, key1 = split_path(path1)
@@ -563,26 +552,6 @@ class S3FileSystem(object):
                 length = size - offset
             bytes = read_block(f, offset, length, delimiter)
         return bytes
-
-
-@contextmanager
-def no_refresh(s3fs):
-    """ Wrap an s3fs with this to temporarily block freshing filecache on writes.
-
-    Use this if writing many small files to a bucket.
-    The filelist will only be refreshed by the next writing action, or
-    explicit call to `s3fs._ls(bucket, refresh=True)`.
-
-    Usage
-    -----
-    >>> with no_refresh(s3fs) as fs:    # doctest: +SKIP
-            [fs.touch('mybucket/file%i'%i) for i in range(1500)] # doctest: +SKIP
-    """
-    s3fs.refresh_off()
-    try:
-        yield s3fs
-    finally:
-        s3fs.refresh_on()
 
 
 class S3File(object):

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -2,7 +2,7 @@
 import io
 import pytest
 from itertools import chain
-from s3fs.core import S3FileSystem, no_refresh
+from s3fs.core import S3FileSystem
 from s3fs.utils import seek_delimiter, ignoring, tmpfile
 import moto
 
@@ -203,22 +203,10 @@ def test_s3_ls(s3):
 
 
 def test_s3_big_ls(s3):
-    with no_refresh(s3) as s3:
-        for x in range(1200):
-            s3.touch(test_bucket_name+'/thousand/%i.part'%x)
-    s3._ls(test_bucket_name, refresh=True)
+    for x in range(1200):
+        s3.touch(test_bucket_name+'/thousand/%i.part'%x)
     assert len(s3.walk(test_bucket_name)) > 1200
     s3.rm(test_bucket_name+'/thousand/', recursive=True)
-
-
-def test_no_refresh(s3):
-    set1 = s3.walk(test_bucket_name)
-    s3.refresh_off()
-    s3.touch(test_bucket_name+'/another')
-    assert set1 == s3.walk(test_bucket_name)
-    s3.refresh_on()
-    s3.touch(test_bucket_name+'/yet_another')
-    assert len(set1) < len(s3.walk(test_bucket_name))
 
 
 def test_s3_ls_detail(s3):

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -573,21 +573,23 @@ def test_append(s3):
     assert s3.cat(test_bucket_name+'/nested/file1') == data
     with s3.open(test_bucket_name+'/nested/file1', 'ab') as f:
         f.write(b'extra')  # append, write, small file
-    assert  s3.cat(test_bucket_name+'/nested/file1') == data+b'extra'
+    assert s3.cat(test_bucket_name+'/nested/file1') == data+b'extra'
 
     with s3.open(a, 'wb') as f:
         f.write(b'a' * 10*2**20)
     with s3.open(a, 'ab') as f:
-        pass # append, no write, big file
+        pass  # append, no write, big file
     assert s3.cat(a) == b'a' * 10*2**20
 
     with s3.open(a, 'ab') as f:
-        f.write(b'extra') # append, small write, big file
+        assert f.parts
+        assert f.tell() == 10*2**20
+        f.write(b'extra')  # append, small write, big file
     assert s3.cat(a) == b'a' * 10*2**20 + b'extra'
 
     with s3.open(a, 'ab') as f:
         assert f.tell() == 10*2**20 + 5
-        f.write(b'b' * 10*2**20) # append, big write, big file
+        f.write(b'b' * 10*2**20)  # append, big write, big file
         assert f.tell() == 20*2**20 + 5
     assert s3.cat(a) == b'a' * 10*2**20 + b'extra' + b'b' *10*2**20
 

--- a/s3fs/utils.py
+++ b/s3fs/utils.py
@@ -116,3 +116,11 @@ def read_block(f, offset, length, delimiter=None):
     f.seek(offset)
     bytes = f.read(length)
     return bytes
+
+
+def raises(exc, lamda):
+    try:
+        lamda()
+        return False
+    except exc:
+        return True


### PR DESCRIPTION
Previously on touch or write events we called `_ls` to update the local
cache.  When we called touch repeatedly this caused a slowdown unless
we used the `no_refresh` context manager.

Now we just invalidate the cache on write events so that the next read
event will correctly update the cache.  This helps with many successive
writes.

cc @martindurant 

This still has a couple of failures.  I'm probably doing something a bit wacky.