### PR TITLE
PR: Expose use_ssl option for S3 client

### DIFF
--- a/s3fs/mapping.py
+++ b/s3fs/mapping.py
@@ -34,13 +34,17 @@ class S3Map(MutableMapping):
         self.s3 = s3 or S3FileSystem.current()
         self.root = root
         if check:
-            s3.touch(root+'/a')
-            s3.rm(root+'/a')
+            self.s3.touch(root+'/a')
+            self.s3.rm(root+'/a')
 
     def clear(self):
         """Remove all keys below root - empties out mapping
         """
-        self.s3.rm(self.root, recursive=True)
+        try:
+            self.s3.rm(self.root, recursive=True)
+        except (IOError, OSError):
+            # ignore non-existance of root
+            pass
 
     def _key_to_str(self, key):
         if isinstance(key, (tuple, list)):

--- a/s3fs/tests/test_mapping.py
+++ b/s3fs/tests/test_mapping.py
@@ -11,6 +11,7 @@ def test_simple(s3):
     assert list(d) == list(d.keys()) == []
     assert list(d.values()) == []
     assert list(d.items()) == []
+    d = S3Map(root, s3, check=True)
 
 
 def test_default_s3filesystem(s3):
@@ -54,6 +55,16 @@ def test_complex_keys(s3):
     print(list(d))
 
     assert ('x', 1, 2) in d
+
+
+def test_clear_empty(s3):
+    d = S3Map(root, s3)
+    d.clear()
+    assert list(d) == []
+    d[1] = b'1'
+    assert list(d) == ['1']
+    d.clear()
+    assert list(d) == []
 
 
 def test_pickle(s3):

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -80,6 +80,11 @@ def test_simple(s3):
         assert out == data
 
 
+def test_ssl_off():
+    s3 = S3FileSystem(use_ssl=False)
+    assert s3.s3.meta.endpoint_url.startswith('http://')
+
+
 def test_tokenize():
     from s3fs.core import tokenize
     a = (1, 2, 3)


### PR DESCRIPTION
For small writes can make a decent speed improvement to turn SSL off, reducing connection overhead.

Also, fix error on Mapping's clear(): the "root" shouldn't need to exist