### PR TITLE
PR: When deleting bucket, invalidate list cache for ''

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -361,7 +361,7 @@ class S3FileSystem(object):
         if split_path(path)[1]:
             return bool(self.ls(path))
         else:
-            return (path in self.ls('') and
+            return (path in self.ls('') or
                     not raises(FileNotFoundError, lambda: self.ls(path)))
 
     def cat(self, path):

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -515,6 +515,7 @@ class S3FileSystem(object):
                     raise IOError('Delete bucket failed', bucket)
                 self.dirs.pop(bucket, None)
                 self.invalidate_cache(bucket)
+                self.invalidate_cache('')
             else:
                 raise IOError('Not empty', path)
 

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -415,6 +415,7 @@ def test_new_bucket(s3):
         s3.rmdir('new/temp')
     s3.rm('new/temp')
     s3.rmdir('new')
+    assert 'new' not in s3.ls('')
     assert not s3.exists('new')
     with pytest.raises((IOError, OSError)):
         s3.ls('new')


### PR DESCRIPTION
Otherwise bucket name would still show up for `ls('')`.

Fixes #43 