### PR TITLE
PR: Fix bad connection caching

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -146,7 +146,6 @@ class S3FileSystem(object):
         anon, key, secret, kwargs, token, ssl = (self.anon, self.key,
                             self.secret, self.kwargs, self.token, self.use_ssl)
         tok = tokenize(anon, key, secret, kwargs, token, ssl)
-        print(anon)
         if refresh:
             self._conn.pop(tok, None)
         logger.debug("Open S3 connection.  Anonymous: %s", self.anon)

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -191,6 +191,7 @@ class S3FileSystem(object):
     def __getstate__(self):
         d = self.__dict__.copy()
         del d['s3']
+        del d['session']
         logger.debug("Serialize with state: %s", d)
         return d
 

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -104,6 +104,7 @@ def test_multiple_objects(s3):
     s3.connect()
     assert s3.ls('test')
     s32 = S3FileSystem(anon=False)
+    assert s32.session
     assert s3.ls('test') == s32.ls('test')
 
 


### PR DESCRIPTION
If relying on a cached connection object, was not creating session
object to go with it.