### PR TITLE
Anon no longer defaults to None

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -74,12 +74,40 @@ Limitations
 This project is meant for convenience, rather than feature completeness.
 The following are known current omissions:
 
-- there is no append-mode on files
-
-- file access is always binary
+- file access is always binary (although readline and iterating by line are
+possible)
 
 - no permissions/access-control (i.e., no chmod/chmown methods)
 
+
+Credentials
+-----------
+
+The AWS key and secret may be provided explicitly when creating an S3FileSystem.
+A more secure way, not including the credentials directly in code, is to allow
+boto to establish the credentials automatically. Boto will try the following
+methods, in order:
+
+- aws_access_key_id, aws_secret_access_key, and aws_session_token environment
+variables
+
+- configuration files such as `~/.aws/credentials`
+
+- for nodes on EC2, the IAM metadata provider
+
+In a distributed environment, it is not expected that raw credentials should
+be passed between machines. In the explicitly provided credentials case, the
+method `get_delegated_s3pars()` can be used to obtain temporary credentials.
+When not using explicit credentials, it should be expected that every machine
+also has the apropriate environment variables, config files or IAM roles
+available.
+
+If none of the credential methods are available, only anonymous access will
+work, and `anon=True` must be passed to the sonstructor.
+
+Furthermore, `S3FileSystem.current()` will return the most-recently created
+instance, so this method could be used in preference to the constructor in
+cases where the code must be agnostic of the credentials/config used.
 
 Contents
 ========

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -126,9 +126,15 @@ def test_delegate(s3):
     s32 = S3FileSystem(**out)
     assert not s32.anon
     assert out == s32.get_delegated_s3pars()
-    s32.anon = True
-    out = s32.get_delegated_s3pars()
+
+
+def test_not_delegate():
+    s3 = S3FileSystem(anon=True)
+    out = s3.get_delegated_s3pars()
     assert out == {'anon': True}
+    s3 = S3FileSystem(anon=False)  # auto credentials
+    out = s3.get_delegated_s3pars()
+    assert out == {'anon': False}
 
 
 def test_ls(s3):


### PR DESCRIPTION
Must now be explicitly specified True or False - no attempt to use
credentials with fallback. No check of successful credentials is made,
error will only happen when an operation is attempted.

If not explicitly provided, but not anonymous, delegation token will
not call STS, but assume that whatever mechanism allowed connection
is available to other S3FileSystem instances (which are potentially on
other machines in the dask-distributed contexct)

Changed docs to reflect these changes, with a short section on
credential usage

Related: https://github.com/dask/dask/issues/1178 https://github.com/dask/dask/pull/1184