### PR TITLE
Add ACL on create, and chmod

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -771,7 +771,10 @@ class S3File(object):
             self._fetch(self.start, self.end + self.blocksize)
 
     def __next__(self):
-        return self.readline()
+        out = self.readline()
+        if not out:
+            raise StopIteration
+        return out
 
     next = __next__
 

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -344,6 +344,8 @@ class S3FileSystem(object):
     def chmod(self, path, acl):
         """ Set Access Control on a bucket/key
 
+        See http://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl
+
         Parameters
         ----------
         path : string

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -673,3 +673,29 @@ def test_no_connection_sharing_among_processes(s3):
     conn_id = executor.submit(_get_s3_id, s3).result()
     assert id(s3.connect()) != conn_id, \
         "Processes should not share S3 connections."
+
+
+@pytest.xfail("In moto, all users are privilaged")
+def test_public_file(s3):
+    other_bucket_name = 's3fs_private_test'
+
+    s3.touch(test_bucket_name)
+    s3.touch(test_bucket_name+'/afile')
+    s3.touch(other_bucket_name, acl='public-read')
+    s3.touch(other_bucket_name+'/afile', acl='public-read')
+
+    s = S3FileSystem(anon=True)
+    with pytest.raises((IOError, OSError)):
+        s.ls(test_bucket_name)
+    s.ls(other_bucket_name)
+
+    s3.chmod(test_bucket_name, acl='public-read')
+    s3.chmod(other_bucket_name, acl='private')
+    with pytest.raises((IOError, OSError)):
+        s.ls(other_bucket_name, refresh=True)
+    assert s.ls(test_bucket_name, refresh=True)
+
+    # public file in private bucket
+    with s3.open(other_bucket_name+'/see_me', 'wb', acl='public-read') as f:
+        f.write(b'hello')
+    assert s.cat(other_bucket_name+'/see_me') == b'hello'

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -575,6 +575,13 @@ def test_iterable(s3):
         assert f.readline(1) == b'1'
         assert f.readline() == b'23'
 
+    with s3.open(a) as f:
+        out = list(f)
+    with s3.open(a) as f:
+        out2 = f.readlines()
+    assert out == out2
+    assert b"".join(out) == data
+
 
 def test_readable(s3):
     with s3.open(a, 'wb') as f:
@@ -675,7 +682,7 @@ def test_no_connection_sharing_among_processes(s3):
         "Processes should not share S3 connections."
 
 
-@pytest.xfail("In moto, all users are privilaged")
+@pytest.mark.xfail()
 def test_public_file(s3):
     other_bucket_name = 's3fs_private_test'
 


### PR DESCRIPTION
Can only used the canned ACLs, nothing role-based. Good enough for
read/write, private/public.

Unfortunately, moto does not enable testing of ACLs - even anonymous users can access everything. I have tested on real S3, and urge others to do so too.

Note that there is no way to actually display the set ACL, but the effects should be noticeable for other users.

Fixes #47 

Additional commit Fixes #57 