### PR TITLE
Allow parts of multipart upload to be equal to the blocksize

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -863,7 +863,7 @@ class S3File(object):
         """
         Write data to buffer.
 
-        Buffer only sent to S3 on flush() or if buffer is bigger than blocksize.
+        Buffer only sent to S3 on flush() or if buffer is greater than or equal to blocksize.
 
         Parameters
         ----------
@@ -876,7 +876,7 @@ class S3File(object):
             raise ValueError('I/O operation on closed file.')
         out = self.buffer.write(ensure_writable(data))
         self.loc += out
-        if self.buffer.tell() > self.blocksize:
+        if self.buffer.tell() >= self.blocksize:
             self.flush()
         return out
 

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -743,3 +743,25 @@ def test_upload_with_s3fs_prefix(s3):
 
     with s3.open(path, 'ab') as f:
         f.write(b'b' * (10 * 2 ** 20))
+
+def test_multipart_upload_blocksize(s3):
+    blocksize = 5 * (2 ** 20)
+    expected_parts = 3
+    with tmpfile() as fn:
+        # Create a tempfile of size `3 * blocksize`
+        with open(fn, 'wb') as f:
+            f.write(b'b' * expected_parts * blocksize)
+
+        # Write the file in chunks of size `blocksize`
+        # This is the same as `S3FileSystem.put`, but `put` doesn't give
+        # access to the S3File for testing
+        with open(fn, 'rb') as f:
+            with s3.open(a, 'wb', block_size=blocksize) as s3f:
+                while True:
+                    data = f.read(blocksize)
+                    if len(data) == 0:
+                        break
+                    s3f.write(data)
+
+        # Ensure that the multipart upload consists of only 3 parts
+        assert len(s3f.parts) == expected_parts


### PR DESCRIPTION
When S3FileSystem.put is used, because chunks are written to
S3File.write in chunks `blocksize` large this results in multipart
uploads that are twice as large, because it takes two writes in order to
surpass `blocksize` number of bytes in the buffer. This change will
cause it to send parts that are equal to `blocksize` when using put.

I have had consistent problems with connection timeouts to s3 with
larger files. With this simple change, I have uploaded many large files
with no problems. I also plan to submit a pull request that allows you
to override the blocksize from S3FileSystem APIs. I hope this is welcome.