### PR TITLE
Continue on more timeout errors

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -1038,4 +1038,9 @@ def _fetch_range(client, bucket, key, start, end, max_attempts=10):
                 return b''
             else:
                 raise
+        except Exception as e:
+            if 'time' in str(e).lower():  # Actual exception type changes often
+                continue
+            else:
+                raise
     raise RuntimeError("Max number of S3 retries exceeded")


### PR DESCRIPTION
I was getting S3 timeout errors.  These became harder to identify in recent versions because all of the timeout errors moved.  From tracebacks it looks like they're now deep within vendored versions of other libraries. 

Rather than try to track these I'm now excepting on *any* exception that contains the text `time`.  This is a hack.  Alternatives welcome.