### PR TITLE
Provide failing unit test to demonstrate missing refresh logic.

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -601,7 +601,7 @@ class S3FileSystem(object):
         if not self.exists(path):
             raise FileNotFoundError(path)
         if recursive:
-            #self.ls(path, refresh=True)
+            self.invalidate_cache(path)
             self.bulk_delete(self.walk(path))
             if not self.exists(path):
                 return

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -601,6 +601,7 @@ class S3FileSystem(object):
         if not self.exists(path):
             raise FileNotFoundError(path)
         if recursive:
+            #self.ls(path, refresh=True)
             self.bulk_delete(self.walk(path))
             if not self.exists(path):
                 return

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -470,16 +470,11 @@ def test_dynamic_add_rm(s3):
     s3.mkdir('one')
     s3.mkdir('one/two')
     assert s3.exists('one')
-    # The following ls is currently causing s3fs to tag 'one/two' as an empty
-    # key but NOT as a directory. 
     s3.ls('one')
     s3.touch("one/two/file_a")
     assert s3.exists('one/two/file_a')
-    # Now 'one/two' should be tagged as a directory since it contains a file
-    # but this recursive rm does NOT find file_a unless another 'ls' is performed:
-    #s3.ls('one', refresh=True) #Retags 'one/two' as a DIRECTORY.
-    #The retagging should probably be done internally by the 'rm' method.
     s3.rm('one', recursive=True)
+    assert not s3.exists('one')
 
 def test_write_small(s3):
     with s3.open(test_bucket_name+'/test', 'wb') as f:

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -466,6 +466,21 @@ def test_new_bucket(s3):
     with pytest.raises((IOError, OSError)):
         s3.ls('new')
 
+def test_dynamic_add_rm(s3):
+    s3.mkdir('one')
+    s3.mkdir('one/two')
+    assert s3.exists('one')
+    # The following ls is currently causing s3fs to tag 'one/two' as an empty
+    # key but NOT as a directory. 
+    s3.ls('one')
+    s3.touch("one/two/file_a")
+    assert s3.exists('one/two/file_a')
+    # Now 'one/two' should be tagged as a directory since it contains a file
+    # but this recursive rm does NOT find file_a unless another 'ls' is performed:
+    #s3.ls('one', refresh=True) #Retags 'one/two' as a DIRECTORY.
+    #The retagging should probably be done internally by the 'rm' method.
+    s3.rm('one', recursive=True)
+
 def test_write_small(s3):
     with s3.open(test_bucket_name+'/test', 'wb') as f:
         f.write(b'hello')


### PR DESCRIPTION
Was looking at using your s3fs for my purposes in an AWS app. One issue I ran into during testing of my app was a failure to bulk remove the s3fs test resources at the end of my test. It seems like there may be some kind of 'separation of concerns' issue going on with the refresh logic. As far as I can tell a particular S3 key is only recognized as a DIRECTORY type key during an '_lsdir' operation. The consequence being that if I do an 'ls' operation and then add a file under a particular key another 'ls' operation must occur before I can successfully bulk remove (remove with recursion) the contents under that key.

The contents of this GITHUB branch (named 'mkdir') demonstrate the problem and one possible solution. The quick fix solution is one line in core.py (see the code diffs). It is commented out for now so you can see the associated test failure that I have added as 'test_dynamic_add_rm' in your test suite named 'test_s3fs.py'

Let me know if you have any questions and thanks for the effort in providing s3fs. I find it quite helpful overall.

-Travis