### PR TITLE
Add support for metadata via {set,get}xattr calls

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -406,6 +406,9 @@ class S3FileSystem(object):
 
         Attributes have to be of the form documented in the `Metadata Reference`_.
 
+        Parameters: key-value pairs like field="value", where the values must be strings. Does not alter existing fields, unless
+        the field appears here - if the value is None, delete the field.
+
         Examples
         --------
         >>> mys3file.setxattr(attribute_1='value1', attribute_2='value2')  # doctest: +SKIP
@@ -430,7 +433,7 @@ class S3FileSystem(object):
                             MetadataDirective='REPLACE')
 
         # refresh metadata
-        self.metadata(path, refresh=True)
+        self._metadata_cache[path] = metadata
 
     def _walk(self, path, refresh=False):
         if path.startswith('s3://'):
@@ -883,6 +886,8 @@ class S3File(object):
         --------
         >>> mys3file.setxattr(attribute_1='value1', attribute_2='value2')  # doctest: +SKIP
         """
+        if self.mode != 'rb':
+            raise NotImplementedError('cannot update metadata while file is open for writing')
         return self.s3.setxattr(self.path, **kwargs)
 
     def url(self):

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -131,14 +131,21 @@ def test_xattr(s3):
     bucket, key = (test_bucket_name, 'tmp/test/xattr')
     filename = bucket + '/' + key
     body = b'aaaa'
+    public_read_acl = {'Permission': 'READ', 'Grantee': {'URI': 'http://acs.amazonaws.com/groups/global/AllUsers', 'Type': 'Group'}}
 
     s3.s3.put_object(Bucket=bucket, Key=key,
+                     ACL='public-read',
                      Metadata=test_xattr_sample_metadata,
                      Body=body)
-    s3file = s3.open(filename)
+
+    # save etag for later
+    etag = s3.info(filename)['ETag']
+    assert public_read_acl in s3.s3.get_object_acl(Bucket=bucket, Key=key)['Grants']
 
     assert s3.getxattr(filename, 'test_xattr') == test_xattr_sample_metadata['test_xattr']
     assert s3.metadata(filename) == test_xattr_sample_metadata
+
+    s3file = s3.open(filename)
     assert s3file.getxattr('test_xattr') == test_xattr_sample_metadata['test_xattr']
     assert s3file.metadata() == test_xattr_sample_metadata
 
@@ -147,6 +154,15 @@ def test_xattr(s3):
     s3file.setxattr(**{'test_xattr': None})
     assert s3file.metadata() == {}
     assert s3.cat(filename) == body
+
+    # check that ACL and ETag are preserved after updating metadata
+    assert public_read_acl in s3.s3.get_object_acl(Bucket=bucket, Key=key)['Grants']
+    assert s3.info(filename)['ETag'] == etag
+
+def test_xattr_setxattr_in_write_mode(s3):
+    s3file = s3.open(a, 'wb')
+    with pytest.raises(NotImplementedError):
+        s3file.setxattr(test_xattr='1')
 
 @pytest.mark.xfail()
 def test_delegate(s3):

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -125,6 +125,28 @@ def test_info(s3):
     assert a not in s3.ls(parent)
     assert s3.info(a)  # now uses head_object
 
+test_xattr_sample_metadata = {'test_xattr': '1'}
+
+def test_xattr(s3):
+    bucket, key = (test_bucket_name, 'tmp/test/xattr')
+    filename = bucket + '/' + key
+    body = b'aaaa'
+
+    s3.s3.put_object(Bucket=bucket, Key=key,
+                     Metadata=test_xattr_sample_metadata,
+                     Body=body)
+    s3file = s3.open(filename)
+
+    assert s3.getxattr(filename, 'test_xattr') == test_xattr_sample_metadata['test_xattr']
+    assert s3.metadata(filename) == test_xattr_sample_metadata
+    assert s3file.getxattr('test_xattr') == test_xattr_sample_metadata['test_xattr']
+    assert s3file.metadata() == test_xattr_sample_metadata
+
+    s3file.setxattr(test_xattr='2')
+    assert s3file.getxattr('test_xattr') == '2'
+    s3file.setxattr(**{'test_xattr': None})
+    assert s3file.metadata() == {}
+    assert s3.cat(filename) == body
 
 @pytest.mark.xfail()
 def test_delegate(s3):


### PR DESCRIPTION
Hi, 

Thanks for this project. It makes working with S3 so much simpler.

Could you add support for S3 metadata? Here is an initial implementation, where I tried to mimic the [xattr Linux interface][1]. Let me know if I should change something.

Thanks!
Pablo

[1]: https://manpages.debian.org/jessie-backports/manpages/xattr.7.en.html