### PR TITLE
Added token parameter to S3FileSystem docstring

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -89,9 +89,11 @@ class S3FileSystem(object):
         uses the key/secret given, or boto's credential resolver (environment
         variables, config files, EC2 IAM server, in that order)
     key : string (None)
-        If not anonymous, use this key, if specified
+        If not anonymous, use this access key ID, if specified
     secret : string (None)
-        If not anonymous, use this password, if specified
+        If not anonymous, use this secret access key, if specified
+    token : string (None)
+        If not anonymous, use this security token, if specified
     use_ssl : bool (True)
         Whether to use SSL in connections to S3; may be faster without, but
         insecure


### PR DESCRIPTION
It was a bit confusing in documentation as token is an accepted parameter,
yet it wasn't included in the docstring (and therefore the generated API docs).

Also used more standard AWS terminology for key/secret/token names.