### PR TITLE
add `config_kwargs` parameter to S3FileSystem

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -103,10 +103,10 @@ class S3FileSystem(object):
     default_block_size: None, int
         If given, the default block size value used for ``open()``, if no
         specific value is given at all time. The built-in default is 5MB.
-    default_fill_cache: Bool (True)
+    default_fill_cache : Bool (True)
         Whether to use cache filling with open by default. Refer to
         ``S3File.open``.
-    config_kwargs: dict of parameters passed to ``botocore.client.Config``
+    config_kwargs : dict of parameters passed to ``botocore.client.Config``
     kwargs : other parameters for boto3 session
 
     Examples

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -93,6 +93,11 @@ def test_client_kwargs():
     assert s3.s3.meta.endpoint_url.startswith('http://foo')
 
 
+def test_config_kwargs():
+    s3 = S3FileSystem(config_kwargs={'signature_version': 's3v4'})
+    assert s3.connect(refresh=True).meta.config.signature_version == 's3v4'
+
+
 def test_tokenize():
     from s3fs.core import tokenize
     a = (1, 2, 3)


### PR DESCRIPTION
It may have other applications for other use cases, but in my case, I need to be able to pass `signature_version='s3v4'` to the `botocore.client.Config` object in order to use s3fs with [Minio](https://minio.io).