### PR TITLE
Use additional kwargs

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -165,7 +165,7 @@ class S3FileSystem(object):
             additional_kwargs.update(self._filter_kwargs(method, akwargs))
         # Add the normal kwargs in
         additional_kwargs.update(kwargs)
-        return method(**kwargs)
+        return method(**additional_kwargs)
 
     @classmethod
     def current(cls):


### PR DESCRIPTION
Recently there have been additional kwargs that are aggregated so
that can be passed through when calling boto methods. These aren't
currently being used. This uses them.