### PR TITLE
Simply ignore flushes if buffer smaller than block size

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -1092,7 +1092,7 @@ class S3File(object):
         """
         Write data to buffer.
 
-        Buffer only sent to S3 on flush() or if buffer is greater than or equal to blocksize.
+        Buffer only sent to S3 on close() or if buffer is greater than or equal to blocksize.
 
         Parameters
         ----------
@@ -1127,8 +1127,8 @@ class S3File(object):
         """
         if self.mode in {'wb', 'ab'} and not self.closed:
             if self.buffer.tell() < self.blocksize and not force:
-                raise ValueError('Parts must be greater than %s',
-                                 self.blocksize)
+                # ignore if not enough data for a block and not closing
+                return
             if self.buffer.tell() == 0:
                 # no data in the buffer to write
                 return

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -1113,7 +1113,8 @@ class S3File(object):
         """
         Write buffered data to S3.
 
-        Uploads the current buffer, if it is larger than the block-size.
+        Uploads the current buffer, if it is larger than the block-size. If
+        the buffer is smaller than the block-size, this is a no-op.
 
         Due to S3 multi-upload policy, you can only safely force flush to S3
         when you are finished writing.  It is unsafe to call this function

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -1117,8 +1117,7 @@ class S3File(object):
         the buffer is smaller than the block-size, this is a no-op.
 
         Due to S3 multi-upload policy, you can only safely force flush to S3
-        when you are finished writing.  It is unsafe to call this function
-        repeatedly.
+        when you are finished writing.
 
         Parameters
         ----------

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -578,11 +578,6 @@ def test_write_fails(s3):
         s3.open(test_bucket_name+'/temp', 'rb').write(b'hello')
     with pytest.raises(ValueError):
         s3.open(test_bucket_name+'/temp', 'wb', block_size=10)
-    with pytest.raises(ValueError):
-        with s3.open(test_bucket_name+'/temp', 'wb') as f:
-            f.write(b'hello')
-            f.flush()
-            f.write(b'world')
     f = s3.open(test_bucket_name+'/temp', 'wb')
     f.close()
     with pytest.raises(ValueError):
@@ -594,6 +589,9 @@ def test_write_fails(s3):
 def test_write_blocks(s3):
     with s3.open(test_bucket_name+'/temp', 'wb') as f:
         f.write(b'a' * 2*2**20)
+        assert f.buffer.tell() == 2*2**20
+        assert not(f.parts)
+        f.flush()
         assert f.buffer.tell() == 2*2**20
         assert not(f.parts)
         f.write(b'a' * 2*2**20)


### PR DESCRIPTION
The current behavior of raising an assertion causes some small files to be unwritable.

For example, with [`io.TextIOWrapper`](https://docs.python.org/2/library/io.html#io.TextIOWrapper) used by `dask.bytes`, a `close()` call internally first calls a `flush()`. And if the buffer was less than the block size, the exception would be raised and the file couldn't be written.