### PR TITLE
Change underlying implementation of info

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -646,8 +646,11 @@ class S3FileSystem(object):
 
     def rmdir(self, path, **kwargs):
         """ Remove empty key or bucket """
+        if path.startswith('s3://'):
+            path = path[len('s3://'):]
+        path = path.rstrip('/')
         bucket, key = split_path(path)
-        if (key and self.du(path, total=True) == 0) or not key:
+        if ((key and self.du(path, total=True) == 0) or not key) and not self._ls(path):
             self.rm(path, **kwargs)
         else:
             raise IOError('Path is not directory-like', path)

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -405,7 +405,8 @@ class S3FileSystem(object):
                     'LastModified': out['LastModified'],
                     'Size': out['ContentLength'], 'StorageClass': "STANDARD"}
             return out
-        except (ClientError, ParamValidationError):
+        except (ClientError, ParamValidationError) as e:
+            logger.debug("Failed to head path %s", path, exc_info=True)
             raise FileNotFoundError(path)
 
     _metadata_cache = {}
@@ -646,7 +647,7 @@ class S3FileSystem(object):
     def rmdir(self, path, **kwargs):
         """ Remove empty key or bucket """
         bucket, key = split_path(path)
-        if (key and self.info(path)['Size'] == 0) or not key:
+        if (key and self.du(path, total=True) == 0) or not key:
             self.rm(path, **kwargs)
         else:
             raise IOError('Path is not directory-like', path)

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -650,7 +650,7 @@ class S3FileSystem(object):
             path = path[len('s3://'):]
         path = path.rstrip('/')
         bucket, key = split_path(path)
-        if ((key and self.du(path, total=True) == 0) or not key) and not self._ls(path):
+        if not self._ls(path) and ((key and self.info(path)['Size'] == 0) or not key):
             self.rm(path, **kwargs)
         else:
             raise IOError('Path is not directory-like', path)

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -153,11 +153,14 @@ def test_info(s3):
     s3.touch(b)
     assert s3.info(a) == s3.ls(a, detail=True)[0]
     parent = a.rsplit('/', 1)[0]
-    s3.dirs[parent].pop(0)  # disappear our file!
-    assert a not in s3.ls(parent)
-    assert s3.info(a)  # now uses head_object
+    s3.dirs.pop(a)  # remove full path from the cache
+    s3.ls(parent)  # fill the cache with parent dir
+    assert s3.info(a) == s3.dirs[parent][0]  # correct value
+    assert id(s3.info(a)) == id(s3.dirs[parent][0])  # is object from cache
+
 
 test_xattr_sample_metadata = {'test_xattr': '1'}
+
 
 def test_xattr(s3):
     bucket, key = (test_bucket_name, 'tmp/test/xattr')

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -263,16 +263,18 @@ def test_rm(s3):
 
 
 def test_rmdir(s3):
+    nested = a + "/nested"
     s3.touch(a)
-    s3.touch(a + "/nested")
+    s3.touch(nested)
     s3.touch(b)
 
-    with pytest.raises(IOError, message="Directory is not empty"):  # doesn't delete non empty directory
+    with pytest.raises(IOError):  # doesn't delete non empty directory
         s3.rmdir(a)
 
-    s3.rmdir(a + "/nested/")
+    s3.rmdir(nested)
     s3.rmdir(a)
     assert a not in s3.ls(test_bucket_name)
+    assert nested not in s3.ls(test_bucket_name)
 
     bucket = 'test1_bucket'
     s3.mkdir(bucket)

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -6,6 +6,7 @@ import re
 import time
 import pytest
 from itertools import chain
+from os.path import join
 from s3fs.core import S3FileSystem
 from s3fs.utils import seek_delimiter, ignoring, tmpfile, SSEParams
 import moto
@@ -259,6 +260,17 @@ def test_rm(s3):
     s3.rm(test_bucket_name, recursive=True)
     assert not s3.exists(test_bucket_name+'/2014-01-01.csv')
     assert not s3.exists(test_bucket_name)
+
+
+def test_rmdir(s3):
+    s3.touch(a)
+    s3.touch(a + "/nested")
+    s3.touch(b)
+    parent = a.rsplit('/', 1)[0]
+    s3.rmdir(parent)  #  issue 109
+
+    with pytest.raises(IOError):  # doesn't delete non empty directory
+        s3.rmdir(test_bucket_name + "/nested")
 
 
 def test_bulk_delete(s3):

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -266,11 +266,18 @@ def test_rmdir(s3):
     s3.touch(a)
     s3.touch(a + "/nested")
     s3.touch(b)
-    parent = a.rsplit('/', 1)[0]
-    s3.rmdir(parent)  #  issue 109
 
-    with pytest.raises(IOError):  # doesn't delete non empty directory
-        s3.rmdir(test_bucket_name + "/nested")
+    with pytest.raises(IOError, message="Directory is not empty"):  # doesn't delete non empty directory
+        s3.rmdir(a)
+
+    s3.rmdir(a + "/nested/")
+    s3.rmdir(a)
+    assert a not in s3.ls(test_bucket_name)
+
+    bucket = 'test1_bucket'
+    s3.mkdir(bucket)
+    s3.rmdir(bucket)
+    assert bucket not in s3.ls('/')
 
 
 def test_bulk_delete(s3):


### PR DESCRIPTION
In the current implementation in order to open a key for read, info method is called, which subsequently performs _ls on file's "directory". This feature makes it impossible to use s3fs when there is a lot of keys under a prefix.

Since one of the most common ways of using s3 is like a key/val store, where metadata about keys are stored in rds and s3 is used as a cheap storage, it would to support this usa case.