### PR TITLE
Add support for bucket versioning

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -150,6 +150,33 @@ encryption parameters in particular.  An instance can be passed instead of a
 regular python dictionary as the `s3_additional_kwargs` parameter.
 
 
+Bucket Version Awareness
+------------------------
+
+If your bucket has object versioning enabled then you can add version-aware support
+to s3fs.  This ensures that if a file is opened at a particular point in time that
+version will be used for reading.
+
+This mitigates the issue where more than one user is concurrently reading and writing
+to the same object.
+
+.. code-block:: python
+
+   s3 = s3fs.S3FileSytem(version_aware=True)
+
+   # Open the file at the latest version
+   fo = s3.open('versioned_bucket/object')
+
+   versions = s3.object_version_info('versioned_bucket/object')
+
+   # open the file at a particular version
+   fo_old_version = s3.open('versioned_bucket/object', version_id='SOMEVERSIONID')
+   >>>
+
+In order for this to function the user must have the necessary IAM permissions to perform
+a GetObjectVersion
+
+
 Contents
 ========
 

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -1351,13 +1351,12 @@ def _fetch_range(client, bucket, key, version_id, start, end, max_attempts=10,
     for i in range(max_attempts):
         try:
             if version_id is not None:
-                kwargs = {'VersionId': version_id}
+                kwargs = dict({'VersionId': version_id}, **req_kw)
             else:
-                kwargs = {}
+                kwargs = req_kw
             resp = client.get_object(Bucket=bucket, Key=key,
                                      Range='bytes=%i-%i' % (start, end - 1),
-                                     **kwargs,
-                                     **req_kw)
+                                     **kwargs)
             return resp['Body'].read()
         except S3_RETRYABLE_ERRORS as e:
             logger.debug('Exception %e on S3 download, retrying', e,

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -383,22 +383,30 @@ class S3FileSystem(object):
         else:
             return [f['Key'] for f in files]
 
-    def info(self, path, version_id=None, **kwargs):
+    def info(self, path, version_id=None, refresh=False, **kwargs):
         """ Detail on the specific file pointed to by path.
 
         Gets details only for a specific key, directories/buckets cannot be
         used with info.
+
+        Parameters
+        ----------
+        version_id : str, optional
+            version of the key to perform the head_object on
+        refresh : bool
+            If true, don't look in the info cache
         """
         parent = path.rsplit('/', 1)[0]
 
-        if path in self.dirs:
-            files = self.dirs[path]
-            if len(files) == 1:
-                return files[0]
-        elif parent in self.dirs:
-            for f in self.dirs[parent]:
-                if f['Key'] == path:
-                    return f
+        if not refresh:
+            if path in self.dirs:
+                files = self.dirs[path]
+                if len(files) == 1:
+                    return files[0]
+            elif parent in self.dirs:
+                for f in self.dirs[parent]:
+                    if f['Key'] == path:
+                        return f
 
         try:
             bucket, key = split_path(path)
@@ -1048,7 +1056,7 @@ class S3File(object):
 
     def info(self, **kwargs):
         """ File information about this path """
-        return self.s3.info(self.path, version_id=self.version_id, **kwargs)
+        return self.s3.info(self.path, version_id=self.version_id, refresh=True, **kwargs)
 
     def metadata(self, refresh=False, **kwargs):
         """ Return metadata of file.


### PR DESCRIPTION
When s3 is used with bucket versioning this adds additional safely to reading objects preventing potential inconsistent state when reading an object whilst something else writes to it.

This also adds a utility to specifically open a given version of the file.

For non-version enabled buckets this should have no change.