### PR TITLE
Minor code cleanup and unit test fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *.pyc
 .cache/
+.pytest_cache/
+.python-version
 .idea/
 __pycache__
 dist/

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,9 @@ install:
   - conda update conda
 
   # Install dependencies
-  - conda create -n test -c conda-forge python=$TRAVIS_PYTHON_VERSION --file requirements.txt --file test_requirements.txt
+  - conda create -n test -c conda-forge python=$TRAVIS_PYTHON_VERSION pip
   - source activate test
+  - pip install -r requirements.txt -r test_requirements.txt
 
 script:
   - py.test -x --doctest-modules --pyargs s3fs

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
   - conda update conda
 
   # Install dependencies
-  - conda create -n test -c conda-forge python=$TRAVIS_PYTHON_VERSION pytest mock moto boto3
+  - conda create -n test -c conda-forge python=$TRAVIS_PYTHON_VERSION --file requirements.txt --file test_requirements.txt
   - source activate test
 
 script:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,7 +3,7 @@ recursive-include docs *.rst
 
 include setup.py
 include README.rst
-include LICENSE
+include LICENSE.txt
 include MANIFEST.in
 include requirements.txt
 

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -115,7 +115,7 @@ class S3FileSystem(object):
         ``S3File.open``.
     version_aware : bool (False)
         Whether to support bucket versioning.  If enable this will require the
-        user to have the neccesary IAM permissions for dealing with versioned
+        user to have the necessary IAM permissions for dealing with versioned
         objects.
     config_kwargs : dict of parameters passed to ``botocore.client.Config``
     kwargs : other parameters for boto3 session

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -7,7 +7,7 @@ import time
 import pytest
 from itertools import chain
 from s3fs.core import S3FileSystem
-from s3fs.utils import seek_delimiter, ignoring, tmpfile, SSEParams
+from s3fs.utils import seek_delimiter, ignoring, SSEParams
 import moto
 
 from botocore.exceptions import NoCredentialsError
@@ -472,14 +472,15 @@ def test_move(s3):
     assert not s3.exists(fn)
 
 
-def test_get_put(s3):
-    with tmpfile() as fn:
-        s3.get(test_bucket_name+'/test/accounts.1.json', fn)
-        data = files['test/accounts.1.json']
-        assert open(fn, 'rb').read() == data
-        s3.put(fn, test_bucket_name+'/temp')
-        assert s3.du(test_bucket_name+'/temp')[test_bucket_name+'/temp'] == len(data)
-        assert s3.cat(test_bucket_name+'/temp') == data
+def test_get_put(s3, tmpdir):
+    test_file = str(tmpdir.join('test.json'))
+
+    s3.get(test_bucket_name+'/test/accounts.1.json', test_file)
+    data = files['test/accounts.1.json']
+    assert open(test_file, 'rb').read() == data
+    s3.put(test_file, test_bucket_name+'/temp')
+    assert s3.du(test_bucket_name+'/temp')[test_bucket_name+'/temp'] == len(data)
+    assert s3.cat(test_bucket_name+'/temp') == data
 
 
 def test_errors(s3):

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -250,9 +250,9 @@ def test_ls_touch(s3):
     s3.touch(a)
     s3.touch(b)
     L = s3.ls(test_bucket_name+'/tmp/test', True)
-    assert set(d['Key'] for d in L) == set([a, b])
+    assert {d['Key'] for d in L} == {a, b}
     L = s3.ls(test_bucket_name+'/tmp/test', False)
-    assert set(L) == set([a, b])
+    assert set(L) == {a, b}
 
 
 def test_rm(s3):
@@ -410,8 +410,8 @@ def test_read_keys_from_bucket(s3):
         file_contents = s3.cat('/'.join([test_bucket_name, k]))
         assert file_contents == data
 
-    assert (s3.cat('/'.join([test_bucket_name, k])) ==
-            s3.cat('s3://' + '/'.join([test_bucket_name, k])))
+        assert (s3.cat('/'.join([test_bucket_name, k])) ==
+                s3.cat('s3://' + '/'.join([test_bucket_name, k])))
 
 
 def test_url(s3):
@@ -737,6 +737,7 @@ def test_readline_blocksize(s3):
 
         result = f.readline()
         expected = b'ab'
+        assert result == expected
 
 
 def test_next(s3):

--- a/s3fs/tests/test_utils.py
+++ b/s3fs/tests/test_utils.py
@@ -1,14 +1,5 @@
-from s3fs.utils import read_block, seek_delimiter, tmpfile
+from s3fs.utils import read_block, seek_delimiter
 import io
-import os
-
-
-def test_tempfile():
-    with tmpfile() as fn:
-        with open(fn, 'w'):
-            pass
-        assert os.path.exists(fn)
-    assert not os.path.exists(fn)
 
 
 def test_read_block():

--- a/s3fs/utils.py
+++ b/s3fs/utils.py
@@ -1,11 +1,7 @@
 
 import array
 from contextlib import contextmanager
-import os
-import tempfile
-import shutil
 import sys
-import re
 
 PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] == 3

--- a/s3fs/utils.py
+++ b/s3fs/utils.py
@@ -123,9 +123,9 @@ def title_case(string):
 
     Parameters
     ----------
-    string : underscore seperated string
+    string : underscore separated string
     """
-    return ''.join([x.capitalize() for x in string.split('_')])
+    return ''.join(x.capitalize() for x in string.split('_'))
 
 
 class ParamKwargsHelper(object):

--- a/s3fs/utils.py
+++ b/s3fs/utils.py
@@ -19,24 +19,6 @@ def ignoring(*exceptions):
         pass
 
 
-@contextmanager
-def tmpfile(extension='', dir=None):
-    extension = '.' + extension.lstrip('.')
-    handle, filename = tempfile.mkstemp(extension, dir=dir)
-    os.close(handle)
-    os.remove(filename)
-
-    try:
-        yield filename
-    finally:
-        if os.path.exists(filename):
-            if os.path.isdir(filename):
-                shutil.rmtree(filename)
-            else:
-                with ignoring(OSError):
-                    os.remove(filename)
-
-
 def seek_delimiter(file, delimiter, blocksize):
     """ Seek current file to next byte after a delimiter bytestring
 

--- a/s3fs/utils.py
+++ b/s3fs/utils.py
@@ -94,7 +94,6 @@ def read_block(f, offset, length, delimiter=None):
         f.seek(start + length)
         seek_delimiter(f, delimiter, 2**16)
         end = f.tell()
-        eof = not f.read(1)
 
         offset = start
         length = end - start

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,0 +1,4 @@
+futures     ; python_version<"3.2"
+mock
+moto>=1.0
+pytest>=2.7.3


### PR DESCRIPTION
* Fix a couple asserts in tests that were either missing or misplaced. For example, one assert was outside the loop it was supposed to be in.
* Remove custom `tmpfile` context manager, since `pytest` has a built-in one. I pegged `pytest` to ≥ 2.7.3 because it has a bugfix that's nice to have for temporary files.
* Use set literal notation in a few places for cleaner code. Also avoids global lookups.
* Add `futures` as a test requirement for Python 2. It was working by chance since it's an indirect dependency of another package.
* Move test requirements to their own file so developers can easily install them locally with pip
* Add a few things to `.gitignore` -  `pytest`'s new cache directory and the `virtualenv` environment file for those of us who don't use conda. 🙂 
* Removed an extraneous `read()` in `read_block()`.
* Fix #133 