### PR TITLE
Use raise_from from six in order to provide more context for failures.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 botocore
 boto3
+six


### PR DESCRIPTION
This is an attempt to get some better exception handling for s3fs.
closes #118
The one key change here is that if a user lacks permissions to a directory `ls` will raise instead of silently returning nothing.  
Alternatively we could throw a warning here.