### PR TITLE
Implement isfile and isdir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,15 +13,14 @@ install:
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - conda config --set always_yes yes --set changeps1 no
-  - conda update conda
 
   # Install dependencies
   - conda create -n test -c conda-forge python=$TRAVIS_PYTHON_VERSION pip
   - source activate test
-  - conda install boto3=1.7.84 botocore=1.10.84 moto=1.3.6 six pytest mock -c conda-forge -y
+  - pip install -r test_requirements.txt
 
 script:
-  - py.test -vv s3fs
+  - BOTO_PATH=/dev/null AWS_ACCESS_KEY_ID=dummy_key AWS_SECRET_ACCESS_KEY=dummy_secret py.test -vv s3fs
 
 notifications:
   email: false

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-botocore
-boto3
-six
+boto3>=1.9.91
+botocore>=1.12.91
+six>=1.12.0

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -469,7 +469,14 @@ class S3FileSystem(object):
         if path.startswith('s3://'):
             path = path[len('s3://'):]
         path = path.rstrip('/')
-        return not path or bool(self._lsdir(path, refresh=refresh, max_items=1))
+        if not path:
+            return True
+        if not refresh:
+            parent = path.rsplit('/', 1)[0]
+            if parent in self.dirs:
+                return any(f['Key'] == path and f['StorageClass'] == 'DIRECTORY'
+                           for f in self.dirs[parent])
+        return bool(self._lsdir(path, refresh=refresh, max_items=1))
 
     def isfile(self, path, refresh=False):
         """ Check if path points to a file.

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -355,7 +355,7 @@ class S3FileSystem(object):
             return fdesc
         return io.TextIOWrapper(fdesc, encoding=encoding)
 
-    def _lsdir(self, path, refresh=False):
+    def _lsdir(self, path, refresh=False, max_items=None):
         if path.startswith('s3://'):
             path = path[len('s3://'):]
         path = path.rstrip('/')
@@ -364,8 +364,11 @@ class S3FileSystem(object):
         if path not in self.dirs or refresh:
             try:
                 pag = self.s3.get_paginator('list_objects_v2')
+                config = {}
+                if max_items:
+                    config.update(MaxItems=max_items, PageSize=2 * max_items)
                 it = pag.paginate(Bucket=bucket, Prefix=prefix, Delimiter='/',
-                                  **self.req_kw)
+                                  PaginationConfig=config, **self.req_kw)
                 files = []
                 dirs = []
                 for i in it:
@@ -449,6 +452,37 @@ class S3FileSystem(object):
             return files
         else:
             return [f['Key'] for f in files]
+
+    def isdir(self, path, refresh=False):
+        """ Check if path points to a directory.
+
+        Check is cached unless `refresh=True`.
+
+        Parameters
+        ----------
+        path : string/bytes
+            location to check
+        refresh : bool
+            If true, don't look in the info cache
+        """
+        if path.startswith('s3://'):
+            path = path[len('s3://'):]
+        path = path.rstrip('/')
+        return not path or bool(self._lsdir(path, refresh=refresh, max_items=1))
+
+    def isfile(self, path, refresh=False):
+        """ Check if path points to a file.
+
+        Check is cached unless `refresh=True`.
+
+        Parameters
+        ----------
+        path : string/bytes
+            location to check
+        refresh : bool
+            If true, don't look in the info cache
+        """
+        return not raises(FileNotFoundError, lambda: self.info(path, refresh=refresh))
 
     def info(self, path, version_id=None, refresh=False, **kwargs):
         """ Detail on the specific file pointed to by path.

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -483,7 +483,8 @@ class S3FileSystem(object):
         refresh : bool
             If true, don't look in the info cache
         """
-        return not raises(FileNotFoundError, lambda: self.info(path, refresh=refresh))
+        return not raises(FileNotFoundError,
+                          lambda: self.info(path.rstrip('/'), refresh=refresh))
 
     def info(self, path, version_id=None, refresh=False, **kwargs):
         """ Detail on the specific file pointed to by path.

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -365,7 +365,7 @@ class S3FileSystem(object):
             try:
                 pag = self.s3.get_paginator('list_objects_v2')
                 config = {}
-                if max_items:
+                if max_items is not None:
                     config.update(MaxItems=max_items, PageSize=2 * max_items)
                 it = pag.paginate(Bucket=bucket, Prefix=prefix, Delimiter='/',
                                   PaginationConfig=config, **self.req_kw)
@@ -384,7 +384,8 @@ class S3FileSystem(object):
                 if is_permission_error(e):
                     raise
                 files = []
-
+            if max_items is not None:
+                return files
             self.dirs[path] = files
         return self.dirs[path]
 

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -268,8 +268,16 @@ def test_isfile(s3):
     assert s3.isfile(a)
 
     assert not s3.isfile(b)
+    assert not s3.isfile(b + '/')
     s3.mkdir(b)
     assert not s3.isfile(b)
+    assert not s3.isfile(b + '/')
+
+    assert not s3.isfile(c)
+    assert not s3.isfile(c + '/')
+    s3.mkdir(c + '/')
+    assert not s3.isfile(c)
+    assert not s3.isfile(c + '/')
 
 
 def test_isdir(s3):
@@ -284,8 +292,16 @@ def test_isdir(s3):
     assert not s3.isdir(a)
 
     assert not s3.isdir(b)
+    assert not s3.isdir(b + '/')
     s3.mkdir(b)
     assert s3.isdir(b)
+    assert s3.isdir(b + '/')
+
+    assert not s3.isdir(c)
+    assert not s3.isdir(c + '/')
+    s3.mkdir(c + '/')
+    assert s3.isdir(c)
+    assert s3.isdir(c + '/')
 
 
 def test_rm(s3):

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -256,6 +256,38 @@ def test_ls_touch(s3):
     assert set(L) == {a, b}
 
 
+def test_isfile(s3):
+    assert s3.isfile(test_bucket_name+'/test/accounts.1.json')
+    assert s3.isfile(test_bucket_name+'/test/accounts.2.json')
+    assert not s3.isfile(test_bucket_name + '/test/accounts.3.json')
+    assert not s3.isfile(test_bucket_name + '/test')
+    assert not s3.isfile(test_bucket_name)
+
+    assert not s3.isfile(a)
+    s3.touch(a)
+    assert s3.isfile(a)
+
+    assert not s3.isfile(b)
+    s3.mkdir(b)
+    assert not s3.isfile(b)
+
+
+def test_isdir(s3):
+    assert not s3.isdir(test_bucket_name+'/test/accounts.1.json')
+    assert not s3.isdir(test_bucket_name+'/test/accounts.2.json')
+    assert not s3.isdir(test_bucket_name + '/test/accounts.3.json')
+    assert s3.isdir(test_bucket_name + '/test')
+    assert s3.isdir(test_bucket_name)
+
+    assert not s3.isdir(a)
+    s3.touch(a)
+    assert not s3.isdir(a)
+
+    assert not s3.isdir(b)
+    s3.mkdir(b)
+    assert s3.isdir(b)
+
+
 def test_rm(s3):
     assert not s3.exists(a)
     s3.touch(a)

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -257,11 +257,14 @@ def test_ls_touch(s3):
 
 
 def test_isfile(s3):
+    assert not s3.isfile('')
+    assert not s3.isfile('/')
+    assert not s3.isfile(test_bucket_name)
+    assert not s3.isfile(test_bucket_name + '/test')
+
+    assert not s3.isfile(test_bucket_name + '/test/foo')
     assert s3.isfile(test_bucket_name+'/test/accounts.1.json')
     assert s3.isfile(test_bucket_name+'/test/accounts.2.json')
-    assert not s3.isfile(test_bucket_name + '/test/accounts.3.json')
-    assert not s3.isfile(test_bucket_name + '/test')
-    assert not s3.isfile(test_bucket_name)
 
     assert not s3.isfile(a)
     s3.touch(a)
@@ -281,11 +284,14 @@ def test_isfile(s3):
 
 
 def test_isdir(s3):
-    assert not s3.isdir(test_bucket_name+'/test/accounts.1.json')
-    assert not s3.isdir(test_bucket_name+'/test/accounts.2.json')
-    assert not s3.isdir(test_bucket_name + '/test/accounts.3.json')
-    assert s3.isdir(test_bucket_name + '/test')
+    assert s3.isdir('')
+    assert s3.isdir('/')
     assert s3.isdir(test_bucket_name)
+    assert s3.isdir(test_bucket_name + '/test')
+
+    assert not s3.isdir(test_bucket_name + '/test/foo')
+    assert not s3.isdir(test_bucket_name + '/test/accounts.1.json')
+    assert not s3.isdir(test_bucket_name + '/test/accounts.2.json')
 
     assert not s3.isdir(a)
     s3.touch(a)
@@ -302,6 +308,15 @@ def test_isdir(s3):
     s3.mkdir(c + '/')
     assert s3.isdir(c)
     assert s3.isdir(c + '/')
+
+    # test cache
+    assert not s3.dirs
+    s3.ls(test_bucket_name + '/nested')
+    assert test_bucket_name + '/nested' in s3.dirs
+    assert not s3.isdir(test_bucket_name + '/nested/file1')
+    assert not s3.isdir(test_bucket_name + '/nested/file2')
+    assert s3.isdir(test_bucket_name + '/nested/nested2')
+    assert s3.isdir(test_bucket_name + '/nested/nested2/')
 
 
 def test_rm(s3):

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,6 +1,2 @@
-boto3==1.9.38
-botocore>=1.12.13
-futures     ; python_version<"3.2"
-mock
-moto>=1.0
-pytest>=2.7.3
+moto>=1.3.7
+pytest>=4.2.0


### PR DESCRIPTION
As per the title, implement `S3FileSystem.isfile` and `isdir`. These will be still useful even after `s3fs` is derived from [fsspec](https://github.com/martindurant/filesystem_spec). `isdir` in particular:
- cannot be delegated to an `s3.info()` call since this would raise `FileNotFoundError` 
- is relatively inexpensive regardless of the number of files in the directory, unlike `ls`.
