### PR TITLE
Add errors parameter to open function

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -302,7 +302,7 @@ class S3FileSystem(object):
         self._kwargs_helper = ParamKwargsHelper(self.s3)
 
     def open(self, path, mode='rb', block_size=None, acl='', version_id=None,
-             fill_cache=None, encoding=None, **kwargs):
+             fill_cache=None, encoding=None, errors=None, **kwargs):
         """ Open a file for reading or writing
 
         Parameters
@@ -350,7 +350,7 @@ class S3FileSystem(object):
                        s3_additional_kwargs=kw)
         if 'b' in mode:
             return fdesc
-        return io.TextIOWrapper(fdesc, encoding=encoding)
+        return io.TextIOWrapper(fdesc, encoding=encoding, errors=errors)
 
     def _lsdir(self, path, refresh=False, max_items=None):
         if path.startswith('s3://'):

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -328,6 +328,8 @@ class S3FileSystem(object):
         encoding : str
             The encoding to use if opening the file in text mode. The platform's
             default text encoding is used if not given.
+        errors : str
+            The error setting of the decoder or encoder
         kwargs: dict-like
             Additional parameters used for s3 methods.  Typically used for
             ServerSideEncryption.


### PR DESCRIPTION
Add errors parameter to open function, which is passed to TextIOWrapper. this will help handle cases of decode errors in utf-8 etc..