### PR TITLE
support for large writes & test updates

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -741,7 +741,6 @@ class S3FileSystem(object):
         refresh : bool (=False)
             if False, look in local cache for files
         """
-        path0 = path
         if path.startswith('s3://'):
             path = path[len('s3://'):]
         path = path.rstrip('/')
@@ -1142,9 +1141,12 @@ class S3File(object):
     See Also
     --------
     S3FileSystem.open: used to create ``S3File`` objects
-    """
 
-    def __init__(self, s3, path, mode='rb', block_size=5 * 2 ** 20, acl="",
+    """
+    part_min = 5 * 2 ** 20
+    part_max = 5 * 2 ** 30
+
+    def __init__(self, s3, path, mode='rb', block_size=part_min, acl="",
                  version_id=None, fill_cache=True, s3_additional_kwargs=None):
         self.mode = mode
         if mode not in {'rb', 'wb', 'ab'}:
@@ -1433,38 +1435,63 @@ class S3File(object):
             if force:
                 self.forced = True
 
-            self.buffer.seek(0)
-            part = len(self.parts) + 1
-            i = 0
-
             try:
                 self.mpu = self.mpu or self._call_s3(
                     self.s3.s3.create_multipart_upload,
                     Bucket=self.bucket, Key=self.key, ACL=self.acl)
-            except (ClientError, ParamValidationError) as e:
-                raise_from(IOError('Initiating write failed: %s' %
-                                   self.path), e)
+            except (ClientError, ParamValidationError) as exc:
+                raise_from(IOError('Initiating write failed: %s' % self.path), exc)
 
-            while True:
-                try:
-                    out = self._call_s3(
-                        self.s3.s3.upload_part,
-                        Bucket=self.bucket,
-                        PartNumber=part, UploadId=self.mpu['UploadId'],
-                        Body=self.buffer.read(), Key=self.key)
-                    break
-                except S3_RETRYABLE_ERRORS:
-                    if i < retries:
-                        logger.debug('Exception %e on S3 write, retrying',
-                                     exc_info=True)
-                        i += 1
-                        continue
+            self.buffer.seek(0)
+
+            # chunk buffer to ensure blocksize respected by multiparts;
+            # look ahead to ensure we don't attempt to write too small or too large a part
+            (data0, data1) = (None, self.buffer.read(self.blocksize))
+            while data1:
+                (data0, data1) = (data1, self.buffer.read(self.blocksize))
+
+                data1_size = len(data1)
+                if 0 < data1_size < self.blocksize:
+                    # last part would be smaller than specified
+                    remainder = data0 + data1
+                    remainder_size = self.blocksize + data1_size
+
+                    if remainder_size <= self.part_max:
+                        # we can combine the last two parts without issue
+                        (data0, data1) = (remainder, None)
                     else:
-                        raise IOError('Write failed after %i retries' % retries,
-                                      self)
-                except Exception as e:
-                    raise IOError('Write failed', self, e)
-            self.parts.append({'PartNumber': part, 'ETag': out['ETag']})
+                        # combination of last two blocks is too large for a single part
+                        #
+                        # this implies blocksize (and data0) must be more than half, and less
+                        # than or equal to, part_max;
+                        # however, data1 could be trivially small (less than part_min).
+                        #
+                        # spread out the data between the last two parts in order to best
+                        # approximate blocksize and avoid part_min:
+                        partition = remainder_size // 2
+                        (data0, data1) = (remainder[:partition], remainder[partition:])
+
+                part = len(self.parts) + 1
+
+                for attempt in range(retries + 1):
+                    try:
+                        out = self._call_s3(
+                            self.s3.s3.upload_part,
+                            Bucket=self.bucket,
+                            PartNumber=part, UploadId=self.mpu['UploadId'],
+                            Body=data0, Key=self.key)
+                    except S3_RETRYABLE_ERRORS:
+                        if attempt < retries:
+                            logger.debug('Exception %e on S3 write, retrying', exc_info=True)
+                    except Exception as exc:
+                        raise IOError('Write failed', self, exc)
+                    else:
+                        break
+                else:
+                    raise IOError('Write failed after %i retries' % retries, self)
+
+                self.parts.append({'PartNumber': part, 'ETag': out['ETag']})
+
             self.buffer = io.BytesIO()
 
     def close(self):

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -533,7 +533,7 @@ def test_url(s3):
     url = s3.url(fn, expires=100)
     assert 'http' in url
     assert '/nested/file1' in url
-    exp = int(re.match(".*?Expires=(\d+)", url).groups()[0])
+    exp = int(re.match(r".*?Expires=(\d+)", url).groups()[0])
     delta = abs(exp - time.time() - 100)
     assert delta < 5
     with s3.open(fn) as f:

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -1135,14 +1135,15 @@ def test_versions(s3):
     with s3.open(versioned_file, 'wb') as fo:
         fo.write(b'2')
     versions = s3.object_version_info(versioned_file)
-    assert len(versions) == 2
+    version_ids = [version['VersionId'] for version in versions]
+    assert len(version_ids) == 2
 
     with s3.open(versioned_file) as fo:
-        assert fo.version_id == '1'
+        assert fo.version_id == version_ids[1]
         assert fo.read() == b'2'
 
-    with s3.open(versioned_file, version_id='0') as fo:
-        assert fo.version_id == '0'
+    with s3.open(versioned_file, version_id=version_ids[0]) as fo:
+        assert fo.version_id == version_ids[0]
         assert fo.read() == b'1'
 
 

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -4,13 +4,18 @@ from concurrent.futures import ProcessPoolExecutor
 import io
 import re
 import time
-import unittest
 import pytest
 from itertools import chain
 from s3fs.core import S3FileSystem, FileNotFoundError
 from s3fs.utils import seek_delimiter, ignoring, SSEParams
 import moto
 import boto3
+
+try:
+    from unittest import mock
+except ImportError:
+    # python 2.7
+    import mock
 
 from botocore.exceptions import NoCredentialsError
 
@@ -727,10 +732,10 @@ def test_write_large(s3):
     payload = b'0' * payload_size
 
     with s3.open(test_bucket_name + '/test', 'wb') as fd, \
-         unittest.mock.patch.object(s3, '_call_s3', side_effect=s3._call_s3) as mock:
+         mock.patch.object(s3, '_call_s3', side_effect=s3._call_s3) as s3_mock:
         fd.write(payload)
 
-    upload_parts = mock.mock_calls[1:]
+    upload_parts = s3_mock.mock_calls[1:]
     upload_sizes = [len(upload_part[2]['Body']) for upload_part in upload_parts]
     assert upload_sizes == [5 * mb, int(7.5 * mb)]
 
@@ -748,12 +753,12 @@ def test_write_limit(s3):
     payload = b'0' * payload_size
 
     with s3.open(test_bucket_name + '/test', 'wb') as fd, \
-         unittest.mock.patch('s3fs.core.S3File.part_max', new=part_max), \
-         unittest.mock.patch.object(s3, '_call_s3', side_effect=s3._call_s3) as mock:
+         mock.patch('s3fs.core.S3File.part_max', new=part_max), \
+         mock.patch.object(s3, '_call_s3', side_effect=s3._call_s3) as s3_mock:
         fd.blocksize = block_size
         fd.write(payload)
 
-    upload_parts = mock.mock_calls[1:]
+    upload_parts = s3_mock.mock_calls[1:]
     upload_sizes = [len(upload_part[2]['Body']) for upload_part in upload_parts]
     assert upload_sizes == [block_size, int(14.5 * mb), int(14.5 * mb)]
 
@@ -775,8 +780,8 @@ def test_write_small_secure(s3):
 
 
 def test_write_large_secure(s3):
-    mock = moto.mock_s3()
-    mock.start()
+    s3_mock = moto.mock_s3()
+    s3_mock.start()
 
     # build our own s3fs with the relevant additional kwarg
     s3 = S3FileSystem(s3_additional_kwargs={'ServerSideEncryption': 'AES256'})

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,3 +1,4 @@
+mock; python_version < '3.3'
 moto>=1.3.7
 pytest>=4.2.0
 pytest-env


### PR DESCRIPTION
### Changes

#### ensure multi-parts written by ``flush()`` respect ``block_size`` and S3 max part size

1) ``flush()`` was properly ensuring that the buffer had reached at
least ``block_size`` in length before writing a part to S3; however, it
was not ensuring that resulting part(s) were themselves at all on the
order of ``block_size``.

2) Nor did the method ensure every part is less than S3's maximum part
size, (regardless of desired ``block_size``).

---

(1) was relatively "easy" to cross -- if a single ``write()`` payload
was of *any* size equal to or greater than ``buffer_size`` -- even many
times larger than ``buffer_size`` -- it was uploaded as is, as a single
part. This itself caused ``flush()`` to violate the expectation of
``buffer_size``, and to operate differently depending on whether the
user wrote their payload in small chunks or big chunks.

Moreover, (1) caused a breaking issue, when a single write payload was
greater than S3's maximum upload (part) limit of 5 GiB. This is a large
string to write, certainly; however, not an unreasonable one, when your
objects are that large -- (and, S3 objects can be much larger than
that).

(For example, see dssg/triage#687 – a pre-existing interface was
extended to enforce proper chunking of 5+ GiB write payloads.)

(1) is fixed by making ``flush()`` read and upload ``block_size`` chunks
from the buffer, (only writing a larger part than that at the end of the
buffer, in order to avoid a smaller-than-``buffer_size`` part).

---

(2) is even more of an edge case, but likely worth handling, at the same
time -- while ``buffer_size`` is (hypothetically) configurable, and up
to the configurer to ensure that it is neither too small nor too large,
so long as ``flush()`` is ever writing parts *larger* than
``buffer_size``, then it is still conceivable for it to request to
upload a part that is larger than S3's maximum. However, this
implies that ``buffer_size`` has been configured to be far larger than
S3's *minimum* -- really, it must be more than half as large as the
maximum -- and therefore ``buffer_size`` may be safely, and trivially,
violated, by uploading the remainder of the buffer in two equal-size
parts, (and satisfying the part size minimum for both).

#### update test ``test_url`` to silence warning

Raw string literal required for regex special characters

#### update test ``test_versions`` for moto v1.3.8

Having created a fresh testing environment, I got moto v1.3.8, which
returns different file version information, requiring a test update.