### PR TITLE
Add conformant walk() implementation, rename old one to find()

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 boto3>=1.9.91
 botocore>=1.12.91
 fsspec>=0.2.2
+more-itertools>=6.0

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -1211,7 +1211,6 @@ def test_pickle_with_passed_in_session(s3):
 
 
 def test_walk__basic(s3):
-    """"""
     expected = [
         (
             test_bucket_name,
@@ -1242,3 +1241,20 @@ def test_walk__basic(s3):
             "Directories don't match in %r." % root
         assert filenames == expected[i][2], \
             "Filenames don't match in %r." % root
+
+
+def test_walk__limit_recursion(s3):
+    result = list(s3.walk(test_bucket_name, 1))
+
+    assert len(result) == 1, 'Wrong number of results: %d != 1' % len(result)
+    assert result[0][0] == test_bucket_name, "Root directory is wrong."
+    assert result[0][1] == ['nested', 'test'], "Directories don't match."
+    assert result[0][2] == [
+        '2014-01-01.csv', '2014-01-02.csv', '2014-01-03.csv', 'file.dat',
+        'filexdat'
+    ], "Files don't match."
+
+
+def test_walk__zero_means_bail(s3):
+    result = list(s3.walk(test_bucket_name, 0))
+    assert not result, 'Wrong number of results: %d != 0' % len(result)

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -1208,3 +1208,37 @@ def test_pickle_with_passed_in_session(s3):
     s3 = S3FileSystem(session=session)
     with pytest.raises(NotImplementedError):
         s3.__getstate__()
+
+
+def test_walk__basic(s3):
+    """"""
+    expected = [
+        (
+            test_bucket_name,
+            ['nested', 'test'],
+            ['2014-01-01.csv', '2014-01-02.csv', '2014-01-03.csv', 'file.dat',
+             'filexdat']
+        ),
+        (
+            test_bucket_name + '/nested',
+            ['nested2'],
+            ['file1', 'file2']
+        ),
+        (
+            test_bucket_name + '/nested/nested2',
+            [],
+            ['file1', 'file2'],
+        ),
+        (
+            test_bucket_name + '/test',
+            [],
+            ['accounts.1.json', 'accounts.2.json'],
+        )
+    ]
+
+    for i, (root, dirnames, filenames) in enumerate(s3.walk(test_bucket_name)):
+        assert root == expected[i][0], "Root directory doesn't match."
+        assert dirnames == expected[i][1], \
+            "Directories don't match in %r." % root
+        assert filenames == expected[i][2], \
+            "Filenames don't match in %r." % root


### PR DESCRIPTION
Closes #107.

**Breaking change:**

* `walk()` now behaves like os.walk() instead of returning a list of all files
* The old `walk()` was renamed to `find()`.