### PR TITLE
Make boto3 exceptions more accurate

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -839,7 +839,7 @@ class S3FileSystem(AbstractFileSystem):
                 self.invalidate_cache(bucket)
                 self.invalidate_cache('')
             else:
-                raise IOError('Not empty', path)
+                raise FileNotFoundError(path)
 
     def invalidate_cache(self, path=None):
         if path is None:
@@ -899,7 +899,7 @@ class S3File(AbstractBufferedFile):
                  version_id=None, fill_cache=True, s3_additional_kwargs=None,
                  autocommit=True, cache_type='bytes'):
         if not split_path(path)[1]:
-            raise IOError('Attempt to open non key-like path: %s' % path)
+            raise ValueError('Attempt to open non key-like path: %s' % path)
         self.version_id = version_id
         self.acl = acl
         self.mpu = None

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -25,11 +25,6 @@ except ImportError:
         socket.timeout,
     )
 
-try:
-    FileNotFoundError = FileNotFoundError
-except NameError:
-    class FileNotFoundError(IOError):
-        pass
 
 # py2 has no ConnectionError only OSError with different error number for each
 # error so we need to catch OSError and compare errno to the following

--- a/s3fs/errors.py
+++ b/s3fs/errors.py
@@ -126,13 +126,13 @@ def translate_boto_error(error, message=None, *args, **kwargs):
 
     An instantiated exception ready to be thrown.
     """
-    code = error.response['Error']['Code']
+    code = error.response['Error'].get('Code', 'Unknown')
     constructor = ERROR_CODE_TO_EXCEPTION.get(code)
     if not constructor:
         # No match found, rethrow the original error
         return error
 
     if not message:
-        message = error.response['Error']['Message']
+        message = error.response['Error'].get('Message', str(error))
 
     return constructor(message, *args, **kwargs)

--- a/s3fs/errors.py
+++ b/s3fs/errors.py
@@ -1,0 +1,137 @@
+"""S3 error codes adapted into more natural Python ones.
+
+Adapted from: https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html
+"""
+
+import errno
+import functools
+
+
+# Fallback values since some systems don't have these
+EREMOTEIO = getattr(errno, 'EREMOTEIO', errno.EIO)
+EREMCHG = getattr(errno, 'EREMCHG', errno.ENOENT)
+
+
+ERROR_CODE_TO_EXCEPTION = {
+    'AccessDenied': PermissionError,
+    'AccountProblem': PermissionError,
+    'AllAccessDisabled': PermissionError,
+    'AmbiguousGrantByEmailAddress': functools.partial(IOError, errno.EINVAL),
+    'AuthorizationHeaderMalformed': functools.partial(IOError, errno.EINVAL),
+    'BadDigest': functools.partial(IOError, errno.EINVAL),
+    'BucketAlreadyExists': FileExistsError,
+    'BucketAlreadyOwnedByYou': FileExistsError,
+    'BucketNotEmpty': functools.partial(IOError, errno.ENOTEMPTY),
+    'CredentialsNotSupported': functools.partial(IOError, errno.EINVAL),
+    'CrossLocationLoggingProhibited': PermissionError,
+    'EntityTooSmall': functools.partial(IOError, errno.EINVAL),
+    'EntityTooLarge': functools.partial(IOError, errno.EMSGSIZE),
+    'ExpiredToken': PermissionError,
+    'IllegalVersioningConfigurationException': functools.partial(IOError, errno.EINVAL),
+    'IncompleteBody': functools.partial(IOError, errno.EINVAL),
+    'IncorrectNumberOfFilesInPostRequest': functools.partial(IOError, errno.EINVAL),
+    'InlineDataTooLarge': functools.partial(IOError, errno.EMSGSIZE),
+    'InternalError': functools.partial(IOError, EREMOTEIO),
+    'InvalidAccessKeyId': PermissionError,
+    'InvalidAddressingHeader': functools.partial(IOError, errno.EINVAL),
+    'InvalidArgument': functools.partial(IOError, errno.EINVAL),
+    'InvalidBucketName': functools.partial(IOError, errno.EINVAL),
+    'InvalidBucketState': functools.partial(IOError, errno.EPERM),
+    'InvalidDigest': functools.partial(IOError, errno.EINVAL),
+    'InvalidEncryptionAlgorithmError': functools.partial(IOError, errno.EINVAL),
+    'InvalidLocationConstraint': functools.partial(IOError, errno.EINVAL),
+    'InvalidObjectState': PermissionError,
+    'InvalidPart': functools.partial(IOError, errno.EINVAL),
+    'InvalidPartOrder': functools.partial(IOError, errno.EINVAL),
+    'InvalidPayer': PermissionError,
+    'InvalidPolicyDocument': functools.partial(IOError, errno.EINVAL),
+    'InvalidRange': functools.partial(IOError, errno.ERANGE),
+    'InvalidRequest': functools.partial(IOError, errno.EINVAL),
+    'InvalidSecurity': PermissionError,
+    'InvalidSOAPRequest': functools.partial(IOError, errno.EINVAL),
+    'InvalidStorageClass': functools.partial(IOError, errno.EINVAL),
+    'InvalidTargetBucketForLogging': functools.partial(IOError, errno.EINVAL),
+    'InvalidToken': functools.partial(IOError, errno.EINVAL),
+    'InvalidURI': functools.partial(IOError, errno.EINVAL),
+    'KeyTooLongError': functools.partial(IOError, errno.ENAMETOOLONG),
+    'MalformedACLError': functools.partial(IOError, errno.EINVAL),
+    'MalformedPOSTRequest': functools.partial(IOError, errno.EINVAL),
+    'MalformedXML': functools.partial(IOError, errno.EINVAL),
+    'MaxMessageLengthExceeded': functools.partial(IOError, errno.EMSGSIZE),
+    'MaxPostPreDataLengthExceededError': functools.partial(IOError, errno.EMSGSIZE),
+    'MetadataTooLarge': functools.partial(IOError, errno.EMSGSIZE),
+    'MethodNotAllowed': functools.partial(IOError, errno.EPERM),
+    'MissingAttachment': functools.partial(IOError, errno.EINVAL),
+    'MissingContentLength': functools.partial(IOError, errno.EINVAL),
+    'MissingRequestBodyError': functools.partial(IOError, errno.EINVAL),
+    'MissingSecurityElement': functools.partial(IOError, errno.EINVAL),
+    'MissingSecurityHeader': functools.partial(IOError, errno.EINVAL),
+    'NoLoggingStatusForKey': functools.partial(IOError, errno.EINVAL),
+    'NoSuchBucket': FileNotFoundError,
+    'NoSuchBucketPolicy': FileNotFoundError,
+    'NoSuchKey': FileNotFoundError,
+    'NoSuchLifecycleConfiguration': FileNotFoundError,
+    'NoSuchUpload': FileNotFoundError,
+    'NoSuchVersion': FileNotFoundError,
+    'NotImplemented': functools.partial(IOError, errno.ENOSYS),
+    'NotSignedUp': PermissionError,
+    'OperationAborted': functools.partial(IOError, errno.EBUSY),
+    'PermanentRedirect': functools.partial(IOError, EREMCHG),
+    'PreconditionFailed': functools.partial(IOError, errno.EINVAL),
+    'Redirect': functools.partial(IOError, EREMCHG),
+    'RestoreAlreadyInProgress': functools.partial(IOError, errno.EBUSY),
+    'RequestIsNotMultiPartContent': functools.partial(IOError, errno.EINVAL),
+    'RequestTimeout': TimeoutError,
+    'RequestTimeTooSkewed': PermissionError,
+    'RequestTorrentOfBucketError': functools.partial(IOError, errno.EPERM),
+    'SignatureDoesNotMatch': PermissionError,
+    'ServiceUnavailable': functools.partial(IOError, errno.EBUSY),
+    'SlowDown': functools.partial(IOError, errno.EBUSY),
+    'TemporaryRedirect': functools.partial(IOError, EREMCHG),
+    'TokenRefreshRequired': functools.partial(IOError, errno.EINVAL),
+    'TooManyBuckets': functools.partial(IOError, errno.EINVAL),
+    'UnexpectedContent': functools.partial(IOError, errno.EINVAL),
+    'UnresolvableGrantByEmailAddress': functools.partial(IOError, errno.EINVAL),
+    'UserKeyMustBeSpecified': functools.partial(IOError, errno.EINVAL),
+    '301': functools.partial(IOError, EREMCHG),     # PermanentRedirect
+    '307': functools.partial(IOError, EREMCHG),     # Redirect
+    '400': functools.partial(IOError, errno.EINVAL),
+    '403': PermissionError,
+    '404': FileNotFoundError,
+    '405': functools.partial(IOError, errno.EPERM),
+    '409': functools.partial(IOError, errno.EBUSY),
+    '412': functools.partial(IOError, errno.EINVAL),    # PreconditionFailed
+    '416': functools.partial(IOError, errno.ERANGE),    # InvalidRange
+    '500': functools.partial(IOError, EREMOTEIO),       # InternalError
+    '501': functools.partial(IOError, errno.ENOSYS),    # NotImplemented
+    '503': functools.partial(IOError, errno.EBUSY),     # SlowDown
+}
+
+
+def error_to_exception(error, message=None, *args, **kwargs):
+    """Convert a ClientError exception into a Python one.
+
+    Parameters
+    ----------
+
+    error : botocore.exceptions.ClientError
+        The exception returned by the boto API.
+    message : str
+        An error message to use for the returned exception. If not given, the
+        error message returned by the server is used instead.
+
+    Returns
+    -------
+
+    An instantiated exception ready to be thrown.
+    """
+    code = error.response['Error']['Code']
+    constructor = ERROR_CODE_TO_EXCEPTION.get(code)
+    if not constructor:
+        # No match found, rethrow the original error
+        return error
+
+    if not message:
+        message = error.response['Error']['Message']
+
+    return constructor(message, *args, **kwargs)

--- a/s3fs/errors.py
+++ b/s3fs/errors.py
@@ -123,17 +123,21 @@ def translate_boto_error(error, message=None, *args, **kwargs):
     message : str
         An error message to use for the returned exception. If not given, the
         error message returned by the server is used instead.
+    *args, **kwargs :
+        Additional arguments to pass to the exception constructor, after the
+        error message. Useful for passing the filename arguments to ``IOError``.
 
     Returns
     -------
 
-    An instantiated exception ready to be thrown.
+    An instantiated exception ready to be thrown. If the error code isn't
+    recognized, an IOError with the original error message is returned.
     """
-    code = error.response['Error'].get('Code', 'Unknown')
+    code = error.response['Error'].get('Code')
     constructor = ERROR_CODE_TO_EXCEPTION.get(code)
     if not constructor:
-        # No match found, rethrow the original error
-        return error
+        # No match found, wrap this in an IOError with the appropriate message.
+        return IOError(errno.EIO, message or str(error), *args)
 
     if not message:
         message = error.response['Error'].get('Message', str(error))

--- a/s3fs/errors.py
+++ b/s3fs/errors.py
@@ -27,6 +27,7 @@ ERROR_CODE_TO_EXCEPTION = {
     'EntityTooSmall': functools.partial(IOError, errno.EINVAL),
     'EntityTooLarge': functools.partial(IOError, errno.EMSGSIZE),
     'ExpiredToken': PermissionError,
+    'IllegalLocationConstraintException': PermissionError,
     'IllegalVersioningConfigurationException': functools.partial(IOError, errno.EINVAL),
     'IncompleteBody': functools.partial(IOError, errno.EINVAL),
     'IncorrectNumberOfFilesInPostRequest': functools.partial(IOError, errno.EINVAL),

--- a/s3fs/errors.py
+++ b/s3fs/errors.py
@@ -109,7 +109,7 @@ ERROR_CODE_TO_EXCEPTION = {
 }
 
 
-def error_to_exception(error, message=None, *args, **kwargs):
+def translate_boto_error(error, message=None, *args, **kwargs):
     """Convert a ClientError exception into a Python one.
 
     Parameters

--- a/s3fs/errors.py
+++ b/s3fs/errors.py
@@ -7,7 +7,10 @@ import errno
 import functools
 
 
-# Fallback values since some systems don't have these
+# Fallback values since some systems might not have these.
+ENAMETOOLONG = getattr(errno, 'ENAMETOOLONG', errno.EINVAL)
+ENOTEMPTY = getattr(errno, 'ENOTEMPTY', errno.EINVAL)
+EMSGSIZE = getattr(errno, 'EMSGSIZE', errno.EINVAL)
 EREMOTEIO = getattr(errno, 'EREMOTEIO', errno.EIO)
 EREMCHG = getattr(errno, 'EREMCHG', errno.ENOENT)
 
@@ -21,17 +24,17 @@ ERROR_CODE_TO_EXCEPTION = {
     'BadDigest': functools.partial(IOError, errno.EINVAL),
     'BucketAlreadyExists': FileExistsError,
     'BucketAlreadyOwnedByYou': FileExistsError,
-    'BucketNotEmpty': functools.partial(IOError, errno.ENOTEMPTY),
+    'BucketNotEmpty': functools.partial(IOError, ENOTEMPTY),
     'CredentialsNotSupported': functools.partial(IOError, errno.EINVAL),
     'CrossLocationLoggingProhibited': PermissionError,
     'EntityTooSmall': functools.partial(IOError, errno.EINVAL),
-    'EntityTooLarge': functools.partial(IOError, errno.EMSGSIZE),
+    'EntityTooLarge': functools.partial(IOError, EMSGSIZE),
     'ExpiredToken': PermissionError,
     'IllegalLocationConstraintException': PermissionError,
     'IllegalVersioningConfigurationException': functools.partial(IOError, errno.EINVAL),
     'IncompleteBody': functools.partial(IOError, errno.EINVAL),
     'IncorrectNumberOfFilesInPostRequest': functools.partial(IOError, errno.EINVAL),
-    'InlineDataTooLarge': functools.partial(IOError, errno.EMSGSIZE),
+    'InlineDataTooLarge': functools.partial(IOError, EMSGSIZE),
     'InternalError': functools.partial(IOError, EREMOTEIO),
     'InvalidAccessKeyId': PermissionError,
     'InvalidAddressingHeader': functools.partial(IOError, errno.EINVAL),
@@ -46,7 +49,7 @@ ERROR_CODE_TO_EXCEPTION = {
     'InvalidPartOrder': functools.partial(IOError, errno.EINVAL),
     'InvalidPayer': PermissionError,
     'InvalidPolicyDocument': functools.partial(IOError, errno.EINVAL),
-    'InvalidRange': functools.partial(IOError, errno.ERANGE),
+    'InvalidRange': functools.partial(IOError, errno.EINVAL),
     'InvalidRequest': functools.partial(IOError, errno.EINVAL),
     'InvalidSecurity': PermissionError,
     'InvalidSOAPRequest': functools.partial(IOError, errno.EINVAL),
@@ -54,13 +57,13 @@ ERROR_CODE_TO_EXCEPTION = {
     'InvalidTargetBucketForLogging': functools.partial(IOError, errno.EINVAL),
     'InvalidToken': functools.partial(IOError, errno.EINVAL),
     'InvalidURI': functools.partial(IOError, errno.EINVAL),
-    'KeyTooLongError': functools.partial(IOError, errno.ENAMETOOLONG),
+    'KeyTooLongError': functools.partial(IOError, ENAMETOOLONG),
     'MalformedACLError': functools.partial(IOError, errno.EINVAL),
     'MalformedPOSTRequest': functools.partial(IOError, errno.EINVAL),
     'MalformedXML': functools.partial(IOError, errno.EINVAL),
-    'MaxMessageLengthExceeded': functools.partial(IOError, errno.EMSGSIZE),
-    'MaxPostPreDataLengthExceededError': functools.partial(IOError, errno.EMSGSIZE),
-    'MetadataTooLarge': functools.partial(IOError, errno.EMSGSIZE),
+    'MaxMessageLengthExceeded': functools.partial(IOError, EMSGSIZE),
+    'MaxPostPreDataLengthExceededError': functools.partial(IOError, EMSGSIZE),
+    'MetadataTooLarge': functools.partial(IOError, EMSGSIZE),
     'MethodNotAllowed': functools.partial(IOError, errno.EPERM),
     'MissingAttachment': functools.partial(IOError, errno.EINVAL),
     'MissingContentLength': functools.partial(IOError, errno.EINVAL),
@@ -102,7 +105,7 @@ ERROR_CODE_TO_EXCEPTION = {
     '405': functools.partial(IOError, errno.EPERM),
     '409': functools.partial(IOError, errno.EBUSY),
     '412': functools.partial(IOError, errno.EINVAL),    # PreconditionFailed
-    '416': functools.partial(IOError, errno.ERANGE),    # InvalidRange
+    '416': functools.partial(IOError, errno.EINVAL),    # InvalidRange
     '500': functools.partial(IOError, EREMOTEIO),       # InternalError
     '501': functools.partial(IOError, errno.ENOSYS),    # NotImplemented
     '503': functools.partial(IOError, errno.EBUSY),     # SlowDown

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -6,7 +6,7 @@ import re
 import time
 import pytest
 from itertools import chain
-from s3fs.core import S3FileSystem, FileNotFoundError
+from s3fs.core import S3FileSystem
 from s3fs.utils import seek_delimiter, ignoring, SSEParams
 import moto
 import boto3

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from contextlib import contextmanager
+import errno
 import json
 from concurrent.futures import ProcessPoolExecutor
 import io
@@ -110,6 +112,14 @@ def s3():
                 client.delete_object(Bucket=secure_bucket_name, Key=k)
             except:
                 pass
+
+
+@contextmanager
+def expect_errno(expected_errno):
+    """Expect an OSError and validate its errno code."""
+    with pytest.raises(OSError) as error:
+        yield
+    assert error.value.errno == expected_errno, 'OSError has wrong error code.'
 
 
 def test_simple(s3):
@@ -250,7 +260,7 @@ def test_not_delegate():
 def test_ls(s3):
     assert set(s3.ls('')) == {test_bucket_name,
                               secure_bucket_name, versioned_bucket_name}
-    with pytest.raises((OSError, IOError)):
+    with pytest.raises(FileNotFoundError):
         s3.ls('nonexistent')
     fn = test_bucket_name + '/test/accounts.1.json'
     assert fn in s3.ls(test_bucket_name + '/test')
@@ -338,9 +348,9 @@ def test_rm(s3):
     assert s3.exists(a)
     s3.rm(a)
     assert not s3.exists(a)
-    with pytest.raises((OSError, IOError)):
+    with pytest.raises(FileNotFoundError):
         s3.rm(test_bucket_name + '/nonexistent')
-    with pytest.raises((OSError, IOError)):
+    with pytest.raises(FileNotFoundError):
         s3.rm('nonexistent')
     s3.rm(test_bucket_name + '/nested', recursive=True)
     assert not s3.exists(test_bucket_name + '/nested/nested2/file1')
@@ -384,7 +394,7 @@ def test_mkdir_client_region_name():
 
 
 def test_bulk_delete(s3):
-    with pytest.raises((OSError, IOError)):
+    with pytest.raises(FileNotFoundError):
         s3.bulk_delete(['nonexistent/file'])
     with pytest.raises(ValueError):
         s3.bulk_delete(['bucket1/file', 'bucket2/file'])
@@ -398,7 +408,8 @@ def test_anonymous_access():
         s3 = S3FileSystem(anon=True)
         assert s3.ls('') == []
         # TODO: public bucket doesn't work through moto
-    with pytest.raises((OSError, IOError)):
+
+    with pytest.raises(PermissionError):
         s3.mkdir('newbucket')
 
 
@@ -418,7 +429,7 @@ def test_s3_file_info(s3):
     assert s3.exists(fn)
     assert not s3.exists(fn + 'another')
     assert s3.info(fn)['Size'] == len(data)
-    with pytest.raises((OSError, IOError)):
+    with pytest.raises(FileNotFoundError):
         s3.info(fn + 'another')
 
 
@@ -548,7 +559,7 @@ def test_seek(s3):
 
 
 def test_bad_open(s3):
-    with pytest.raises(IOError):
+    with pytest.raises(ValueError):
         s3.open('')
 
 
@@ -579,23 +590,23 @@ def test_get_put(s3, tmpdir):
 
 
 def test_errors(s3):
-    with pytest.raises((IOError, OSError)):
+    with pytest.raises(FileNotFoundError):
         s3.open(test_bucket_name + '/tmp/test/shfoshf', 'rb')
 
     # This is fine, no need for interleaving directories on S3
     # with pytest.raises((IOError, OSError)):
     #    s3.touch('tmp/test/shfoshf/x')
 
-    with pytest.raises((IOError, OSError)):
+    with pytest.raises(FileNotFoundError):
         s3.rm(test_bucket_name + '/tmp/test/shfoshf/x')
 
-    with pytest.raises((IOError, OSError)):
+    with pytest.raises(FileNotFoundError):
         s3.mv(test_bucket_name + '/tmp/test/shfoshf/x', 'tmp/test/shfoshf/y')
 
-    with pytest.raises((IOError, OSError)):
+    with pytest.raises(ValueError):
         s3.open('x', 'rb')
 
-    with pytest.raises(IOError):
+    with pytest.raises(FileNotFoundError):
         s3.rm('unknown')
 
     with pytest.raises(ValueError):
@@ -607,7 +618,7 @@ def test_errors(s3):
         f.close()
         f.read()
 
-    with pytest.raises((IOError, OSError)):
+    with pytest.raises(ValueError):
         s3.mkdir('/')
 
     with pytest.raises(ValueError):
@@ -669,13 +680,14 @@ def test_new_bucket(s3):
     assert s3.exists('new')
     with s3.open('new/temp', 'wb') as f:
         f.write(b'hello')
-    with pytest.raises((IOError, OSError)):
+    with expect_errno(errno.ENOTEMPTY):
         s3.rmdir('new')
+
     s3.rm('new/temp')
     s3.rmdir('new')
     assert 'new' not in s3.ls('')
     assert not s3.exists('new')
-    with pytest.raises((IOError, OSError)):
+    with pytest.raises(FileNotFoundError):
         s3.ls('new')
 
 
@@ -776,7 +788,7 @@ def test_write_fails(s3):
     f.close()
     with pytest.raises(ValueError):
         f.write(b'hello')
-    with pytest.raises((OSError, IOError)):
+    with pytest.raises(FileNotFoundError):
         s3.open('nonexistentbucket/temp', 'wb').close()
 
 
@@ -984,13 +996,13 @@ def test_public_file(s3):
         s3.touch(other_bucket_name + '/afile', acl='public-read')
 
         s = S3FileSystem(anon=True)
-        with pytest.raises((IOError, OSError)):
+        with pytest.raises(PermissionError):
             s.ls(test_bucket_name)
         s.ls(other_bucket_name)
 
         s3.chmod(test_bucket_name, acl='public-read')
         s3.chmod(other_bucket_name, acl='private')
-        with pytest.raises((IOError, OSError)):
+        with pytest.raises(PermissionError):
             s.ls(other_bucket_name, refresh=True)
         assert s.ls(test_bucket_name, refresh=True)
 


### PR DESCRIPTION
Right now, if you try reading a file with expired credentials, you get a `FileNotFoundError`. This is pretty confusing. Now that we support Python 3 only, we can be *much* more specific about the kinds of errors we're throwing.

I pulled a list of all the S3 error codes from [here](https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html) and made approximations of what the most logical error code could be.

### Bugfixes

* When attempting to delete a nonexistent bucket, an `IOError` was thrown with the message "not empty." The proper exception is a `FileNotFoundError` because the bucket wasn't found.
* Fixed a number of `IOError` calls that were passing invalid arguments. According to [the documentation](https://docs.python.org/3/library/exceptions.html#OSError), if multiple arguments are passed, the first argument is [an errno code](https://docs.python.org/3/library/errno.html) and the second argument is an error message. Passing invalid arguments can break handler code that's expecting an integer as the error code, not a string.
* Some logging calls were missing arguments to the string formatter.
* Some logging calls used `%e` to display the error message. `%e` is used for floating-point numbers, so I changed this to `%r`.

### Breaking(ish) changes

* `ParamValidationError` is now rethrown as a `ValueError`. Before it was always rethrown as an `IOError` even though this was a programmer error, not an I/O problem.
* `FileNotFoundError` is no longer defined in `core.py`. Since this is Python 3 only now, the only code that should be importing it is Python 2 code, which would immediately break anyway because this can't be installed.

### Other changes

Removed legacy `raise_from` since it's no longer necessary. `s3fs` no longer relies on `six`.