### PR TITLE
Missing autocommit for fs.open()

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -900,7 +900,7 @@ class S3File(AbstractBufferedFile):
     def __init__(self, s3, path, mode='rb', block_size=5 * 2 ** 20, acl="",
                  version_id=None, fill_cache=True, s3_additional_kwargs=None,
                  autocommit=True, cache_type='bytes'):
-        bucket, key = split_path(self.path)
+        bucket, key = split_path(path)
         if not key:
             raise ValueError('Attempt to open non key-like path: %s' % path)
         self.bucket = bucket

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -253,7 +253,7 @@ class S3FileSystem(AbstractFileSystem):
                 'token': cred['SessionToken'], 'anon': False}
 
     def _open(self, path, mode='rb', block_size=None, acl='', version_id=None,
-              fill_cache=None, cache_type='bytes', **kwargs):
+              fill_cache=None, cache_type='bytes', autocommit=True, **kwargs):
         """ Open a file for reading or writing
 
         Parameters
@@ -299,7 +299,8 @@ class S3FileSystem(AbstractFileSystem):
 
         return S3File(self, path, mode, block_size=block_size, acl=acl,
                       version_id=version_id, fill_cache=fill_cache,
-                      s3_additional_kwargs=kw, cache_type=cache_type)
+                      s3_additional_kwargs=kw, cache_type=cache_type,
+                      autocommit=autocommit)
 
     def _lsdir(self, path, refresh=False, max_items=None):
         if path.startswith('s3://'):


### PR DESCRIPTION
This adds in autocommit to the .open api.  Seems it was missing?