### PR TITLE
API/ENH: Validate uploaded content

### DIFF
--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -1338,3 +1338,16 @@ def test_seek_reads(s3):
         size = 17562187
         d3 = f.read(size)
         assert len(d3) == size
+
+
+def test_consistency_check(monkeypatch, s3):
+    from unittest import mock
+
+    monkeypatch.setattr(s3, 'consistency', 'md5')
+    data = b'123'
+
+    fn = test_bucket_name + "/test-consistency"
+
+    with s3.open(fn, "wb") as f:
+        assert f.consistency == "md5"
+        f.write(data)


### PR DESCRIPTION
Validates that the data received by S3 matches what we send.

This matches the API from gcsfs. 3 options: md5, size, none. The default is md5.

One thing I don't understand: doesn't S3 validate `size` by default, and there's no way to disable it? From https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.upload_part

> ContentLength (integer) -- Size of the body in bytes. This parameter is useful when the size of the body cannot be determined automatically.

I guess it Boto should be able to determine the length of a bytestring?

Closes #103 

