### PR TITLE
Locks down version of fsspec for #225

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 boto3>=1.9.91
 botocore>=1.12.91
-fsspec>=0.2.2
+fsspec>=0.2.2,<=0.4.1


### PR DESCRIPTION
Applies workaround from https://github.com/dask/s3fs/issues/225#issuecomment-525990684 (Thanks to @meneal)

this fix can be applied while pending on a fix from `fsspec`.