### PR TITLE
PKG: Remove universal wheels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 .idea/
 __pycache__
 dist/
+*.egg-info
+build/

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[bdist_wheel]
-universal: 1
-
 [metadata]
 long_description: file: README.rst
 


### PR DESCRIPTION
Universal wheels are for packages that work with Python 2 & 3.