### PR TITLE
Always use multipart uploads when not autocommitting

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -972,7 +972,12 @@ class S3File(AbstractBufferedFile):
                     self.details = self.fs.info(self.path)
                     self.version_id = self.details.get('VersionId')
 
-        self.append_block = False
+        # when not using autocommit we want to have transactional state to manage
+        if self.autocommit:
+            self.append_block = False
+        else:
+            self.append_block = True
+
         if 'a' in mode and s3.exists(path):
             loc = s3.info(path)['size']
             if loc < 5 * 2 ** 20:

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -1062,7 +1062,7 @@ class S3File(AbstractBufferedFile):
         logger.debug("Upload for %s, final=%s, loc=%s, buffer loc=%s" % (
             self, final, self.loc, self.buffer.tell()
         ))
-        if not self.append_block and final and self.tell() < self.blocksize:
+        if not self.autocommit and not self.append_block and final and self.tell() < self.blocksize:
             # only happens when closing small file, use on-shot PUT
             data1 = False
         else:

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -973,10 +973,7 @@ class S3File(AbstractBufferedFile):
                     self.version_id = self.details.get('VersionId')
 
         # when not using autocommit we want to have transactional state to manage
-        if self.autocommit:
-            self.append_block = False
-        else:
-            self.append_block = True
+        self.append_block = False
 
         if 'a' in mode and s3.exists(path):
             loc = s3.info(path)['size']
@@ -992,7 +989,7 @@ class S3File(AbstractBufferedFile):
                                 **kwargs)
 
     def _initiate_upload(self):
-        if not self.append_block and self.tell() < self.blocksize:
+        if not self.autocommit and not self.append_block and self.tell() < self.blocksize:
             # only happens when closing small file, use on-shot PUT
             return
         logger.debug("Initiate upload for %s" % self)

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -1297,6 +1297,16 @@ def test_autocommit(s3):
         fo.commit()
 
 
+def test_autocommit_mpu(s3):
+    """When not autocommitting we always want to use multipart uploads"""
+    path = test_bucket_name + '/auto_commit_with_mpu'
+    with s3.open(path, 'wb', autocommit=True) as fo:
+        fo.write(b'1')
+    # fo.flush()
+    assert fo.mpu is not None
+    assert len(fo.parts) == 1
+
+
 def test_touch(s3):
     # create
     fn = test_bucket_name + "/touched"


### PR DESCRIPTION
When not autocommitting the mpu that is created is the best way to
ensure that transactional style commits can be performed elsewhere.

Alternatively we could add another flag to S3File that controls this