### PR TITLE
Use autofunction for S3Map sphinx autosummary

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -46,7 +46,7 @@ API
 
 .. currentmodule:: s3fs.mapping
 
-.. autoclass:: S3Map
+.. autofunction:: S3Map
 
 .. currentmodule:: s3fs.utils
 


### PR DESCRIPTION
`S3Map` was changed from a class to a function in #161. This PR updates the sphinx autosummary accordingly.

Closes #250