### PR TITLE
Propagate req_kw from the filesystem to opened files.

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -256,7 +256,7 @@ class S3FileSystem(AbstractFileSystem):
                 'token': cred['SessionToken'], 'anon': False}
 
     def _open(self, path, mode='rb', block_size=None, acl='', version_id=None,
-              fill_cache=None, cache_type=None, autocommit=True, **kwargs):
+              fill_cache=None, cache_type=None, autocommit=True, requester_pays=None, **kwargs):
         """ Open a file for reading or writing
 
         Parameters
@@ -285,6 +285,9 @@ class S3FileSystem(AbstractFileSystem):
         cache_type : str
             See fsspec's documentation for available cache_type values. Set to "none"
             if no caching is desired. If None, defaults to ``self.default_cache_type``.
+        requester_pays : bool (optional)
+            If RequesterPays buckets are supported.  If None, defaults to the
+            value used when creating the S3FileSystem (which defaults to False.)
         kwargs: dict-like
             Additional parameters used for s3 methods.  Typically used for
             ServerSideEncryption.
@@ -293,6 +296,8 @@ class S3FileSystem(AbstractFileSystem):
             block_size = self.default_block_size
         if fill_cache is None:
             fill_cache = self.default_fill_cache
+        if requester_pays is None:
+            requester_pays = bool(self.req_kw)
 
         acl = acl or self.s3_additional_kwargs.get('ACL', '')
         kw = self.s3_additional_kwargs.copy()
@@ -307,7 +312,7 @@ class S3FileSystem(AbstractFileSystem):
         return S3File(self, path, mode, block_size=block_size, acl=acl,
                       version_id=version_id, fill_cache=fill_cache,
                       s3_additional_kwargs=kw, cache_type=cache_type,
-                      autocommit=autocommit)
+                      autocommit=autocommit, requester_pays=requester_pays)
 
     def _lsdir(self, path, refresh=False, max_items=None):
         if path.startswith('s3://'):
@@ -888,6 +893,8 @@ class S3File(AbstractBufferedFile):
         Optional version to read the file at.  If not specified this will
         default to the current version of the object.  This is only used for
         reading.
+    requester_pays : bool (False)
+        If RequesterPays buckets are supported.
 
     Examples
     --------
@@ -906,7 +913,7 @@ class S3File(AbstractBufferedFile):
 
     def __init__(self, s3, path, mode='rb', block_size=5 * 2 ** 20, acl="",
                  version_id=None, fill_cache=True, s3_additional_kwargs=None,
-                 autocommit=True, cache_type='bytes'):
+                 autocommit=True, cache_type='bytes', requester_pays=False):
         bucket, key = split_path(path)
         if not key:
             raise ValueError('Attempt to open non key-like path: %s' % path)
@@ -920,6 +927,7 @@ class S3File(AbstractBufferedFile):
         self.parts = None
         self.fill_cache = fill_cache
         self.s3_additional_kwargs = s3_additional_kwargs or {}
+        self.req_kw = {'RequestPayer': 'requester'} if requester_pays else {}
         super().__init__(s3, path, mode, block_size, autocommit=autocommit,
                          cache_type=cache_type)
         self.s3 = self.fs  # compatibility
@@ -1024,7 +1032,7 @@ class S3File(AbstractBufferedFile):
         return self.fs.url(self.path, **kwargs)
 
     def _fetch_range(self, start, end):
-        return _fetch_range(self.fs.s3, self.bucket, self.key, self.version_id, start, end)
+        return _fetch_range(self.fs.s3, self.bucket, self.key, self.version_id, start, end, req_kw=self.req_kw)
 
     def _upload_chunk(self, final=False):
         bucket, key = split_path(self.path)

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -1339,3 +1339,13 @@ def test_connect_many():
     pool.close()
     pool.join()
 
+
+def test_requester_pays():
+    fn = test_bucket_name + "/myfile"
+    with moto.mock_s3():
+        s3 = S3FileSystem(requester_pays=True)
+        assert s3.req_kw["RequestPayer"] == "requester"
+        s3.mkdir(test_bucket_name)
+        s3.touch(fn)
+        with s3.open(fn, "rb") as f:
+            assert f.req_kw["RequestPayer"] == "requester"


### PR DESCRIPTION
This allows files opened from a filesystem created with
request_payer=True to also be accessed with the appropriate
RequestPayer headers.

Currently, the requester_pays kwarg to S3FileSystem only works for listing keys, etc., but has no effect when you actually open a file to read data. The following will thus result in an access denied error:

```
fs = s3fs.S3FileSystem(requester_pays=True)
with fs.open("bucket/key") as f:
   print(f.read())
```

There doesn't seem to be any way to specify that the file object should also be requester_pays, and I think it makes sense that this should be the default.

In the meantime, for anyone else running into this issue, here's a monkey patch that I'm currently using which accomplishes the same thing.  Probably also illustrates why it'd be much easier to have this implemented upstream!

```
def _patch_fs_request_payer(fs: s3fs.S3FileSystem):
    """
    HACK: Patches an S3FileSystem instance to use RequestPayer: requester on opened files, not
    just directory listings, if the filesystem is initialized with requester_pays=True.
    """

    import types
    from s3fs.core import _fetch_range

    def fetch_range_with_req_kw(self, start, end):
        return _fetch_range(self.fs.s3, self.bucket, self.key, self.version_id, start, end, req_kw=self.fs.req_kw)

    def patched_open(self, *args, **kwargs) -> s3fs.S3File:
        f = original_open(*args, **kwargs)
        f._fetch_range = types.MethodType(fetch_range_with_req_kw, f)
        if hasattr(f, "cache"):
            f.cache.fetcher = f._fetch_range
        return f

    original_open = fs._open
    fs._open = types.MethodType(patched_open, fs)
```
