### PR TITLE
Add changelog to docs

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,0 +1,16 @@
+Changelog
+=========
+
+Upcoming Release (TBD)
+----------------------
+
+- New instances no longer need reconnect (:pr:`244`) by `Martin Durant`_
+- Always use multipart uploads when not autocommitting (:pr:`243`) by `Marius van Niekerk`_
+- Create ``CONTRIBUTING.md`` (:pr:`248`) by `Jacob Tomlinson`_
+- Use autofunction for ``S3Map`` sphinx autosummary (:pr:`251`) by `James Bourbeau`_
+- Miscellaneous doc updates (:pr:`252`) by `James Bourbeau`_ 
+
+.. _`Martin Durant`: https://github.com/martindurant
+.. _`Marius van Niekerk`: https://github.com/mariusvniekerk
+.. _`Jacob Tomlinson`: https://github.com/jacobtomlinson
+.. _`James Bourbeau`: https://github.com/jrbourbeau

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -35,6 +35,7 @@ extensions = [
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
     'sphinx.ext.autosummary',
+    'sphinx.ext.extlinks',
     'numpydoc',
 ]
 
@@ -110,6 +111,10 @@ pygments_style = 'sphinx'
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
+
+extlinks = {
+    "pr": ("https://github.com/dask/s3fs/pull/%s", "PR #"),
+}
 
 
 # -- Options for HTML output ----------------------------------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -184,6 +184,7 @@ Contents
 .. toctree::
    install
    api
+   changelog
    :maxdepth: 2
 
 


### PR DESCRIPTION
This PR adds a changelog page to the documentation. I've included entries for all PRs merged since the latest release (`0.3.5`). 

Closes #147