### PR TITLE
Don't call super init until init is done

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -161,7 +161,6 @@ class S3FileSystem(AbstractFileSystem):
 
         if self._cached:
             return
-        super().__init__()
         self.anon = anon
         self.session = None
         self.passed_in_session = session
@@ -187,6 +186,7 @@ class S3FileSystem(AbstractFileSystem):
         self.use_ssl = use_ssl
         self.s3 = self.connect()
         self._kwargs_helper = ParamKwargsHelper(self.s3)
+        super().__init__()
 
     def _filter_kwargs(self, s3_method, kwargs):
         return self._kwargs_helper.filter_dict(s3_method.__name__, kwargs)

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -1337,3 +1337,18 @@ def test_seek_reads(s3):
         size = 17562187
         d3 = f.read(size)
         assert len(d3) == size
+
+
+def test_connect_many():
+    from multiprocessing.pool import ThreadPool
+
+    def task(i):
+        S3FileSystem(anon=False).ls("")
+        return True
+
+    pool = ThreadPool(processes=20)
+    out = pool.map(task, range(40))
+    assert all(out)
+    pool.close()
+    pool.join()
+


### PR DESCRIPTION
@TomAugspurger , I wonder if you think this might finally fix the auth problems. Now, the super init is only called after connect. This is important, because the super init sets the cached flag, which then skips the rest of the init for a new invokation - this means that it might have been possible for one invocation of the same instance to be done with init while another call of the same thing is still undergoing connect().