### PR TITLE
Override isdir to not include parent directory ls #258

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -519,7 +519,7 @@ class S3FileSystem(AbstractFileSystem):
             return False
 
         # This only returns things within the path and NOT the path object itself
-        return 0 < len(self._lsdir(path))
+        return bool(self._lsdir(path))
 
     def ls(self, path, detail=False, refresh=False, **kwargs):
         """ List single "directory" with or without details

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -496,6 +496,16 @@ class S3FileSystem(AbstractFileSystem):
                 raise ValueError('Failed to head path %r: %s' % (path, e))
         return super().info(path)
 
+    def isdir(self, path):
+        path = self._strip_protocol(path).rstrip("/")
+        bucket, prefix = split_path(path)
+        if prefix:
+            # This should only return files or directories within this path
+            return 0 < len(self._ls(path))
+        else:
+            # Send buckets to super
+            return super(S3FileSystem, self).isdir(path)
+
     def ls(self, path, detail=False, refresh=False, **kwargs):
         """ List single "directory" with or without details
 


### PR DESCRIPTION
This can help avoid potentially unexpected long calls when the parent directory contains many subdirectories which must all be listed. This also uses self._ls under the hood so the dircache still gets filled and used.