### PR TITLE
TST: Clear instance cache between tests.

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -143,6 +143,7 @@ class S3FileSystem(AbstractFileSystem):
     read_timeout = 15
     default_block_size = 5 * 2**20
     protocol = 's3'
+    _extra_tokenize_attributes = ('default_block_size',)
 
     def __init__(self, anon=False, key=None, secret=None, token=None,
                  use_ssl=True, client_kwargs=None, requester_pays=False,

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -94,6 +94,7 @@ def s3():
         for flist in [files, csv_files, text_files, glob_files]:
             for f, data in flist.items():
                 client.put_object(Bucket=test_bucket_name, Key=f, Body=data)
+        S3FileSystem.clear_instance_cache()
         s3 = S3FileSystem(anon=False)
         s3.invalidate_cache()
         yield s3


### PR DESCRIPTION
Precursor to https://github.com/intake/filesystem_spec/pull/181.

It seems that with that refactor, some of additional state lives between tests, which is causing failures.

```
=================================== FAILURES ===================================

____________________ test_pickle_without_passed_in_session _____________________

s3 = <s3fs.core.S3FileSystem object at 0x7ff133337b50>

    def test_pickle_without_passed_in_session(s3):

        import pickle

        s3 = S3FileSystem()

>       pickle.dumps(s3)

E       AttributeError: Can't pickle local object 'lazy_call.<locals>._handler'
```

I don't fully understand what is actually different, but removing instance caches between tests "fixes" it.