### PR TITLE
Add more s3 fs schemes (s3a://, s3n://)

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -31,8 +31,6 @@ except ImportError:
 
 _VALID_FILE_MODES = {'r', 'w', 'a', 'rb', 'wb', 'ab'}
 
-S3_SCHEMES = ['s3://', 's3a://', 's3n://']
-
 key_acls = {'private', 'public-read', 'public-read-write',
             'authenticated-read', 'aws-exec-read', 'bucket-owner-read',
             'bucket-owner-full-control'}


### PR DESCRIPTION
s3a:// is the official schema used by Hadoop (s3 and s3n are deprecated in hadoop-aws jar)
https://cwiki.apache.org/confluence/display/HADOOP2/AmazonS3

Motivation: Be able to keep a consistent fs scheme across different PySpark, s3fs/PyArrow calls