### PR TITLE
Switch to botocore

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,12 +3,12 @@ s3fs
 
 |Build Status| |Doc Status|
 
-S3FS builds on boto3_ to provide a convenient Python filesystem interface for S3.
+S3FS builds on botocore_ to provide a convenient Python filesystem interface for S3.
 
 View the documentation_ for s3fs.
 
 .. _documentation: http://s3fs.readthedocs.io/en/latest/
-.. _boto3: https://boto3.readthedocs.io/en/latest/
+.. _botocore: https://botocore.readthedocs.io/en/latest/
 
 .. |Build Status| image:: https://travis-ci.org/dask/s3fs.svg?branch=master
     :target: https://travis-ci.org/dask/s3fs

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 numpydoc
-boto3
+botocore
 sphinx
 sphinx-rtd-theme

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,7 +1,7 @@
 S3Fs
 ====
 
-S3Fs is a Pythonic file interface to S3.  It builds on top of boto3_.
+S3Fs is a Pythonic file interface to S3.  It builds on top of botocore_.
 
 The top-level class ``S3FileSystem`` holds connection information and allows
 typical file-system style operations like ``cp``, ``mv``, ``ls``, ``du``,
@@ -188,7 +188,7 @@ Contents
    :maxdepth: 2
 
 
-.. _boto3: https://boto3.readthedocs.io/en/latest/
+.. _botocore: https://botocore.readthedocs.io/en/latest/
 
 Indices and tables
 ==================

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-boto3>=1.9.91
 botocore>=1.12.91
 fsspec>=0.6.0

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -6,7 +6,8 @@ import time
 
 from fsspec import AbstractFileSystem
 from fsspec.spec import AbstractBufferedFile
-import boto3
+import botocore
+import botocore.session
 from botocore.client import Config
 from botocore.exceptions import ClientError, ParamValidationError, BotoCoreError
 
@@ -22,12 +23,9 @@ logger.addHandler(handle)
 if "S3FS_LOGGING_LEVEL" in os.environ:
     logger.setLevel(os.environ["S3FS_LOGGING_LEVEL"])
 
-try:
-    from boto3.s3.transfer import S3_RETRYABLE_ERRORS
-except ImportError:
-    S3_RETRYABLE_ERRORS = (
-        socket.timeout,
-    )
+S3_RETRYABLE_ERRORS = (
+    socket.timeout,
+)
 
 _VALID_FILE_MODES = {'r', 'w', 'a', 'rb', 'wb', 'ab'}
 
@@ -46,7 +44,7 @@ class S3FileSystem(AbstractFileSystem):
     storage.
 
     Provide credentials either explicitly (``key=``, ``secret=``) or depend
-    on boto's credential methods. See boto3 documentation for more
+    on boto's credential methods. See botocore documentation for more
     information. If no credentials are available, use ``anon=True``.
 
     Parameters
@@ -66,7 +64,7 @@ class S3FileSystem(AbstractFileSystem):
         insecure
     s3_additional_kwargs : dict of parameters that are used when calling s3 api
         methods. Typically used for things like "ServerSideEncryption".
-    client_kwargs : dict of parameters for the boto3 client
+    client_kwargs : dict of parameters for the botocore client
     requester_pays : bool (False)
         If RequesterPays buckets are supported.
     default_block_size: int (None)
@@ -84,7 +82,7 @@ class S3FileSystem(AbstractFileSystem):
         user to have the necessary IAM permissions for dealing with versioned
         objects.
     config_kwargs : dict of parameters passed to ``botocore.client.Config``
-    kwargs : other parameters for boto3 session
+    kwargs : other parameters for core session
     session : botocore Session object to be used for all connections.
          This session will be used inplace of creating a new session inside S3FileSystem.
 
@@ -207,24 +205,24 @@ class S3FileSystem(AbstractFileSystem):
             self.anon, self.key, self.secret, self.kwargs,
             self.client_kwargs, self.token, self.use_ssl)
 
+        if not self.passed_in_session:
+            self.session = botocore.session.Session(**self.kwargs)
+
+        logger.debug("Setting up s3fs instance")
+
         if self.anon:
             from botocore import UNSIGNED
             conf = Config(connect_timeout=self.connect_timeout,
                           read_timeout=self.read_timeout,
                           signature_version=UNSIGNED, **self.config_kwargs)
-            if not self.passed_in_session:
-                self.session = boto3.Session(**self.kwargs)
+            self.s3 = self.session.create_client('s3', config=conf, use_ssl=ssl,
+                                        **self.client_kwargs)
         else:
             conf = Config(connect_timeout=self.connect_timeout,
                           read_timeout=self.read_timeout,
                           **self.config_kwargs)
-            if not self.passed_in_session:
-                self.session = boto3.Session(self.key, self.secret, self.token,
-                                             **self.kwargs)
-
-        logger.debug("Setting up s3fs instance")
-        self.s3 = self.session.client('s3', config=conf, use_ssl=ssl,
-                                      **self.client_kwargs)
+            self.s3 = self.session.create_client('s3', aws_access_key_id=self.key, aws_secret_access_key=self.secret, aws_session_token=self.token, config=conf, use_ssl=ssl,
+                                        **self.client_kwargs)
         return self.s3
 
     def get_delegated_s3pars(self, exp=3600):
@@ -247,7 +245,7 @@ class S3FileSystem(AbstractFileSystem):
                     'anon': False}
         if self.key is None or self.secret is None:  # automatic credentials
             return {'anon': False}
-        sts = self.session.client('sts')
+        sts = self.session.create_client('sts')
         cred = sts.get_session_token(DurationSeconds=exp)['Credentials']
         return {'key': cred['AccessKeyId'], 'secret': cred['SecretAccessKey'],
                 'token': cred['SessionToken'], 'anon': False}
@@ -772,30 +770,8 @@ class S3FileSystem(AbstractFileSystem):
         except ParamValidationError as e:
             raise ValueError('Copy failed (%r -> %r): %s' % (path1, path2, e))
 
-    def copy_managed(self, path1, path2, **kwargs):
-        buc1, key1 = self.split_path(path1)
-        buc2, key2 = self.split_path(path2)
-        copy_source = {
-            'Bucket': buc1,
-            'Key': key1
-        }
-        try:
-            self.s3.copy(
-                CopySource=copy_source,
-                Bucket=buc2,
-                Key=key2,
-                ExtraArgs=self._get_s3_method_kwargs(
-                    self.s3.copy_object,
-                    kwargs
-                )
-            )
-        except ClientError as e:
-            raise translate_boto_error(e)
-        except ParamValidationError as e:
-            raise ValueError('Copy failed (%r -> %r): %s' % (path1, path2, e))
-
     def copy(self, path1, path2, **kwargs):
-        self.copy_managed(path1, path2, **kwargs)
+        self.copy_basic(path1, path2, **kwargs)
         self.invalidate_cache(path2)
 
     def bulk_delete(self, pathlist, **kwargs):
@@ -892,7 +868,7 @@ class S3File(AbstractBufferedFile):
     Parameters
     ----------
     s3 : S3FileSystem
-        boto3 connection
+        botocore connection
     path : string
         S3 bucket/key to access
     mode : str

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -11,7 +11,7 @@ import fsspec.core
 from s3fs.core import S3FileSystem
 from s3fs.utils import ignoring, SSEParams
 import moto
-import boto3
+import botocore
 from unittest import mock
 from botocore.exceptions import NoCredentialsError
 
@@ -52,18 +52,22 @@ d = test_bucket_name + '/tmp/test/d'
 def s3():
     # writable local S3 system
     with moto.mock_s3():
-        import boto3
-        client = boto3.client('s3')
+        from botocore.session import Session
+        session = Session()
+        client = session.create_client('s3')
         client.create_bucket(Bucket=test_bucket_name, ACL='public-read')
 
-        bucket = client.create_bucket(
+        client.create_bucket(
             Bucket=versioned_bucket_name, ACL='public-read')
-        bucket_versioning = boto3.resource(
-            's3').BucketVersioning(versioned_bucket_name)
-        bucket_versioning.enable()
+        client.put_bucket_versioning(
+            Bucket=versioned_bucket_name,
+            VersioningConfiguration={
+                'Status': 'Enabled'
+            }
+        )
 
         # initialize secure bucket
-        bucket = client.create_bucket(
+        client.create_bucket(
             Bucket=secure_bucket_name, ACL='public-read')
         policy = json.dumps({
             "Version": "2012-10-17",
@@ -1205,7 +1209,7 @@ def test_change_defaults_only_subsequent():
 
 
 def test_passed_in_session_set_correctly(s3):
-    session = boto3.session.Session()
+    session = botocore.session.Session()
     s3 = S3FileSystem(session=session)
     assert s3.passed_in_session is session
     client = s3.connect()
@@ -1213,7 +1217,7 @@ def test_passed_in_session_set_correctly(s3):
 
 
 def test_without_passed_in_session_set_unique(s3):
-    session = boto3.session.Session()
+    session = botocore.session.Session()
     s3 = S3FileSystem()
     assert s3.passed_in_session is None
     client = s3.connect()
@@ -1228,9 +1232,9 @@ def test_pickle_without_passed_in_session(s3):
 
 def test_pickle_with_passed_in_session(s3):
     import pickle
-    session = boto3.session.Session()
+    session = botocore.session.Session()
     s3 = S3FileSystem(session=session)
-    with pytest.raises((AttributeError, NotImplementedError, TypeError)):
+    with pytest.raises((AttributeError, NotImplementedError, TypeError, pickle.PicklingError)):
         pickle.dumps(s3)
 
 


### PR DESCRIPTION
Given the discussion in #276 I wanted to do a quick POC to see what it would be like to switch s3fs to `botocore` instead of `boto3`.

Most of the changes here are just switching library names and slightly tweaking the way the sessions are constructed as there are some minor differences (keys are given to the client, not the session).

All calls to S3 have remained exactly the same as `boto3` is just handing off to `botocore` underneath with one notable exception.

The `client('s3').copy()` method is not available in `botocore` and after having a dig through the `boto3` codebase it seems quite involved to implement as it enables multi-threaded multi-part transfers between buckets. However I did notice there was an unused `copy_basic` method already implemented which uses the API implementation of `copy_object` and so switched to use that instead.

The result of this is that bucket-bucket transfers may be slower.