### PR TITLE
Only configure the logger if S3FS_LOGGING_LEVEL is set

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -81,9 +81,14 @@ The following are known current omissions:
 Logging
 -------
 
-The logger ``s3fs.core.logger`` provides information about the operations of the
-file system. To see messages, set its level to ``DEBUG``. You can also achieve this via
-an environment variable ``S3FS_LOGGING_LEVEL=DEBUG``.
+The logger named ``s3fs`` provides information about the operations of the file
+system.  To quickly see all messages, you can set the environment variable
+``S3FS_LOGGING_LEVEL=DEBUG``.  The presence of this environment variable will
+install a handler for the logger that prints messages to stderr and set the log
+level to the given value.  More advance logging configuration is possible using
+Python's standard `logging framework`_.
+
+.. _logging framework: https://docs.python.org/3/library/logging.html
 
 Credentials
 -----------

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -14,12 +14,13 @@ from s3fs.errors import translate_boto_error
 from s3fs.utils import ParamKwargsHelper
 
 logger = logging.getLogger('s3fs')
-handle = logging.StreamHandler()
-formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s '
-                              '- %(message)s')
-handle.setFormatter(formatter)
-logger.addHandler(handle)
+
 if "S3FS_LOGGING_LEVEL" in os.environ:
+    handle = logging.StreamHandler()
+    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s '
+                                  '- %(message)s')
+    handle.setFormatter(formatter)
+    logger.addHandler(handle)
     logger.setLevel(os.environ["S3FS_LOGGING_LEVEL"])
 
 try:


### PR DESCRIPTION
Allows people to opt-in to the basic logger config which outputs s3fs
messages while by default avoiding interfering with application-level
logging config.

The premise for piggy-backing on S3FS_LOGGING_LEVEL is that anyone
setting it expects to see some log output.  Anyone who doesn't want to
see log output can either not set it themselves or ensure it is unset
before s3fs is loaded.

Resolves #282.