### PR TITLE
Make S3FileSystem read_timeout and connection_timeout configurable

### DIFF
--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -169,6 +169,23 @@ def test_config_kwargs():
     assert s3.connect(refresh=True).meta.config.signature_version == 's3v4'
 
 
+def test_config_kwargs_class_attributes_default():
+    s3 = S3FileSystem()
+    assert s3.connect(refresh=True).meta.config.connect_timeout == 5
+    assert s3.connect(refresh=True).meta.config.read_timeout == 15
+
+
+def test_config_kwargs_class_attributes_override():
+    s3 = S3FileSystem(
+        config_kwargs={
+            "connect_timeout": 60,
+            "read_timeout": 120,
+        }
+    )
+    assert s3.connect(refresh=True).meta.config.connect_timeout == 60
+    assert s3.connect(refresh=True).meta.config.read_timeout == 120
+
+
 def test_idempotent_connect(s3):
     con1 = s3.connect()
     con2 = s3.connect(refresh=False)


### PR DESCRIPTION
# Description
When initiliazing an S3FileSystem object, it is possible to configure the botocore session as per the parameter "config_kwargs". However, if one tries to configure the config parameters "connect_timeout" or "read_timeout" per config_kwargs, the S3FileSystem can not be created. This is unexpected behaviour in so far as the the config_kwargs parameter suggests that every field of the session config can be configured.

# Analysis
The reason for this is that these two values are hardwired into the boto config object:
```
conf = Config(connect_timeout=self.connect_timeout,
                          read_timeout=self.read_timeout,
                          **self.config_kwargs)
```
This will lead to the following error, if "connect_timeout" or "read_timeout" are part of the config_kwargs: 
```
TypeError: type object got multiple values for keyword argument 'connect_timeout'
```

# Solution
We needed to configure the "connect_timeout" and "read_timeout" and found ourselves unable to do so. There is a suggested workaround which is hack-ish and inconvenient: https://github.com/dask/s3fs/issues/198
We implemented a solution that uses the values from config_kwargs if they are set and defaults to the class attributes if not.