### PR TITLE
Implement checksum for S3FileSystem

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -500,14 +500,19 @@ class S3FileSystem(AbstractFileSystem):
 
         listing = self.ls(path, detail=True, refresh=refresh)
         
+        def get_checksum(item):
+            if item["type"] != 'directory':
+                return item["ETag"].strip('"')
+            else:
+                return tokenize(item)
+             
         if not listing:
             raise FileNotFoundError(path)
         elif len(listing)==1:
-            return int(listing[0]["ETag"].strip('"'), 16)
+            return int(get_checksum(listing[0]), 16)
         else:
-            return int(tokenize(self.info(path)), 16)
-
-        return checksum
+            return int(tokenize([get_checksum(x) for x in listing]), 16)
+        
 
     def isdir(self, path):
         path = self._strip_protocol(path).strip("/")

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -492,7 +492,7 @@ class S3FileSystem(AbstractFileSystem):
         Parameters
         ----------
         path : string/bytes
-            location at which to list files
+            file or path to get checksum for
         refresh : bool (=False)
             if False, look in local cache for file details first
         

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -46,8 +46,6 @@ a = test_bucket_name + '/tmp/test/a'
 b = test_bucket_name + '/tmp/test/b'
 c = test_bucket_name + '/tmp/test/c'
 d = test_bucket_name + '/tmp/test/d'
-e1 = test_bucket_name + '/tmp/test/e1'
-e2 = test_bucket_name + '/tmp/test/e2'
 
 @pytest.yield_fixture
 def s3():
@@ -91,7 +89,7 @@ def s3():
         })
         client.put_bucket_policy(Bucket=secure_bucket_name, Policy=policy)
 
-        for k in [a, b, c, d, e1, e2]:
+        for k in [a, b, c, d]:
             try:
                 client.delete_object(Bucket=test_bucket_name, Key=k)
             except:
@@ -112,7 +110,7 @@ def s3():
                         Bucket=secure_bucket_name, Key=f, Body=data)
                 except:
                     pass
-        for k in [a, b, c, d, e1, e2]:
+        for k in [a, b, c, d]:
             try:
                 client.delete_object(Bucket=test_bucket_name, Key=k)
                 client.delete_object(Bucket=secure_bucket_name, Key=k)


### PR DESCRIPTION
- Implement `S3FileSystem.checksum` that exposes the `refresh` parameter
- For files, use the ETag field for this purpose; for directories, use a hash of the output of `ls(path, detail=True)`, similar to the default implementation in `AbstractFileSystem`; if the path contains multiple files/directories, use a hash of the list of checksums of the individual items