### PR TITLE
Address info() performance issue

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -556,8 +556,9 @@ class S3FileSystem(AbstractFileSystem):
             except ParamValidationError as e:
                 raise ValueError('Failed to head path %r: %s' % (path, e))
 
-            # We could look for a prefix.
             try:
+                # We check to see if the path is a directory by attempting to list its
+                # contexts. If anything is found, it is indeed a directory
                 out = self._call_s3(
                     self.s3.list_objects_v2,
                     kwargs,
@@ -581,7 +582,7 @@ class S3FileSystem(AbstractFileSystem):
             except ClientError as e:
                 raise translate_boto_error(e)
             except ParamValidationError as e:
-                raise ValueError("Failed to head path %r: %s" % (path, e))
+                raise ValueError("Failed to list path %r: %s" % (path, e))
 
         return super().info(path)
     

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -533,7 +533,8 @@ class S3FileSystem(AbstractFileSystem):
                                  "filesystem is not version aware")
         bucket, key, path_version_id = self.split_path(path)
         version_id = _coalesce_version_id(path_version_id, version_id)
-        if self.version_aware or (key and self._ls_from_cache(path) is None) or refresh:
+        should_fetch = (key and self._ls_from_cache(path) is None) or refresh
+        if self.version_aware or should_fetch:
             try:
                 out = self._call_s3(self.s3.head_object, kwargs, Bucket=bucket,
                                     Key=key, **version_id_kw(version_id), **self.req_kw)
@@ -556,6 +557,7 @@ class S3FileSystem(AbstractFileSystem):
             except ParamValidationError as e:
                 raise ValueError('Failed to head path %r: %s' % (path, e))
 
+        if should_fetch:
             try:
                 # We check to see if the path is a directory by attempting to list its
                 # contexts. If anything is found, it is indeed a directory

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -533,8 +533,8 @@ class S3FileSystem(AbstractFileSystem):
                                  "filesystem is not version aware")
         bucket, key, path_version_id = self.split_path(path)
         version_id = _coalesce_version_id(path_version_id, version_id)
-        should_fetch = (key and self._ls_from_cache(path) is None) or refresh
-        if self.version_aware or should_fetch:
+        should_fetch_from_s3 = (key and self._ls_from_cache(path) is None) or refresh
+        if self.version_aware or should_fetch_from_s3:
             try:
                 out = self._call_s3(self.s3.head_object, kwargs, Bucket=bucket,
                                     Key=key, **version_id_kw(version_id), **self.req_kw)
@@ -557,7 +557,7 @@ class S3FileSystem(AbstractFileSystem):
             except ParamValidationError as e:
                 raise ValueError('Failed to head path %r: %s' % (path, e))
 
-        if should_fetch:
+        if should_fetch_from_s3:
             try:
                 # We check to see if the path is a directory by attempting to list its
                 # contexts. If anything is found, it is indeed a directory


### PR DESCRIPTION
Address performance issue discuss in https://github.com/dask/s3fs/issues/320.

Update info() method to use list_objects_v2(maxKey=1) to determine whether a particular path is a directory not.
    
It will try to avoid calling super.info(), this will result pretty expensive operations.