### PR TITLE
Fix 2 exception causes in core.py

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -1293,7 +1293,7 @@ class S3File(AbstractBufferedFile):
                                      exc_info=True)
                     time.sleep(1.7**attempt * 0.1)
                 except Exception as exc:
-                    raise IOError('Write failed: %r' % exc)
+                    raise IOError('Write failed: %r' % exc) from exc
             else:
                 raise IOError('Write failed after %i retries' % self.retries)
 
@@ -1400,7 +1400,7 @@ def _fetch_range(client, bucket, key, version_id, start, end, max_attempts=10,
             if e.response['Error'].get('Code', 'Unknown') in ['416',
                                                               'InvalidRange']:
                 return b''
-            raise translate_boto_error(e)
+            raise translate_boto_error(e) from e
         except Exception as e:
             if 'time' in str(e).lower():  # Actual exception type changes often
                 continue


### PR DESCRIPTION
I recently went over [Matplotlib](https://github.com/matplotlib/matplotlib/pull/16706), [Pandas](https://github.com/pandas-dev/pandas/pull/32322) and [NumPy](https://github.com/numpy/numpy/pull/15731), fixing a small mistake in the way that Python 3's exception chaining is used. If you're interested, I can do it here too. I've done it in just 2 cases for now.

The mistake is this: In some parts of the code, an exception is being caught and replaced with a more user-friendly error. In these cases the syntax `raise new_error from old_error` needs to be used.

Python 3's exception chaining means it shows not only the traceback of the current exception, but that of the original exception (and possibly more.) This is regardless of `raise from`. The usage of `raise from` tells Python to put a more accurate message between the tracebacks. Instead of this: 

    During handling of the above exception, another exception occurred:

You'll get this: 

    The above exception was the direct cause of the following exception:

The first is inaccurate, because it signifies a bug in the exception-handling code itself, which is a separate situation than wrapping an exception.

Let me know what you think! 