### PR TITLE
Fix checksum for multipart uploads

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -616,7 +616,7 @@ class S3FileSystem(AbstractFileSystem):
         info = self.info(path, refresh=refresh)
 
         if info["type"] != 'directory':
-            return int(info["ETag"].strip('"'), 16)
+            return int(info["ETag"].strip('"').split('-')[0], 16)
         else:
             return int(tokenize(info), 16)
 


### PR DESCRIPTION
checksum() fails if the object is created using the multipart upload feature of S3. This is because the resulting ETag is in a slightly different format: _hash_-_num_parts_. This PR addresses the problem by parsing the _hash_ part only and discarding the rest.