### PR TITLE
Ensure S3 client exists before creating S3 keyword helper

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -186,7 +186,6 @@ class S3FileSystem(AsyncFileSystem):
             weakref.finalize(self, sync, self.loop, self._s3.close)
         else:
             self._s3 = None
-        self._kwargs_helper = ParamKwargsHelper(self.s3)
 
     @property
     def s3(self):
@@ -305,6 +304,7 @@ class S3FileSystem(AsyncFileSystem):
             self.session = aiobotocore.get_session(**self.kwargs)
         s3creator = self.session.create_client('s3', config=conf, **init_kwargs, **client_kwargs)
         self._s3 = await s3creator.__aenter__()
+        self._kwargs_helper = ParamKwargsHelper(self.s3)
         return self._s3
 
     connect = sync_wrapper(_connect)


### PR DESCRIPTION
Currently when creating a `S3FileSystem` with `asynchronous=True`, an error is raised as we're trying at access the `.s3` property prior to creating an S3 client:

```python
In [1]: import s3fs

In [2]: s3 = s3fs.S3FileSystem(asynchronous=True)
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
<ipython-input-2-59def4c342c4> in <module>
----> 1 s3 = s3fs.S3FileSystem(asynchronous=True)

~/miniforge3/envs/s3fs-dev/lib/python3.8/site-packages/fsspec/spec.py in __call__(cls, *args, **kwargs)
     53             return cls._cache[token]
     54         else:
---> 55             obj = super().__call__(*args, **kwargs)
     56             # Setting _fs_token here causes some static linters to complain.
     57             obj._fs_token_ = token

~/projects/dask/s3fs/s3fs/core.py in __init__(self, anon, key, secret, token, use_ssl, client_kwargs, requester_pays, default_block_size, default_fill_cache, default_cache_type, version_aware, config_kwargs, s3_additional_kwargs, session, username, password, asynchronous, loop, **kwargs)
    187         else:
    188             self._s3 = None
--> 189         self._kwargs_helper = ParamKwargsHelper(self.s3)
    190
    191     @property

~/projects/dask/s3fs/s3fs/core.py in s3(self)
    192     def s3(self):
    193         if self._s3 is None:
--> 194             raise RuntimeError("please await ``._connect`` before anything else")
    195         return self._s3
    196

RuntimeError: please await ``._connect`` before anything else
```

This PR moves the point where we access the `.s3` property in `S3FileSystem.__init__` to `S3FileSystem._connect` to ensure that we've created an S3 client first. 