### PR TITLE
add sign to filesystem class

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -1209,13 +1209,9 @@ class S3FileSystem(AsyncFileSystem):
             # This path is a bucket or folder, which do not currently have a modified date
             raise IsADirectoryError
         return info['LastModified'].replace(tzinfo=None)
-    def sign(self, path, expiration=100):
-        import boto3
-        client = boto3.client('s3')
-        return client.generate_presigned_url('s3',
-                                             Params={'Bucket': host,
-                                                     'Key': path.partition(host)[-1]},
-                                             ExpiresIn=datetime.timedelta(minutes=5).seconds)
+
+    def sign(self, path, expiration=100, **kwargs):
+        return self.url(path, expires=expiration, **kwargs)
 
 
 class S3File(AbstractBufferedFile):

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -1209,6 +1209,13 @@ class S3FileSystem(AsyncFileSystem):
             # This path is a bucket or folder, which do not currently have a modified date
             raise IsADirectoryError
         return info['LastModified'].replace(tzinfo=None)
+    def sign(self, path, expiration=100):
+        import boto3
+        client = boto3.client('s3')
+        return client.generate_presigned_url('s3',
+                                             Params={'Bucket': host,
+                                                     'Key': path.partition(host)[-1]},
+                                             ExpiresIn=datetime.timedelta(minutes=5).seconds)
 
 
 class S3File(AbstractBufferedFile):


### PR DESCRIPTION
This will enable downstream classes to specify how to sign urls, providing short term URLs for situations where the URL is needed but permissioning needs to be tightly controlled.

Note that currently this adds a boto3 dep, which I'd like to discuss.

xref: https://github.com/intake/filesystem_spec/pull/376