### PR TITLE
fixed resource leak in S3FileSystem._get_file()

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -722,13 +722,16 @@ class S3FileSystem(AsyncFileSystem):
             self.s3.get_object, Bucket=bucket, Key=key,
             **version_id_kw(version_id or vers),
         )
-        with open(lpath, "wb") as f0:
-            body = resp['Body']
-            while True:
-                chunk = await body.read(2**16)
-                if not chunk:
-                    break
-                f0.write(chunk)
+        body = resp['Body']
+        try:
+            with open(lpath, "wb") as f0:
+                while True:
+                    chunk = await body.read(2**16)
+                    if not chunk:
+                        break
+                    f0.write(chunk)
+        finally:
+            body.close()
 
     async def _info(self, path, bucket=None, key=None, kwargs={}, version_id=None):
         if bucket is None:


### PR DESCRIPTION
S3FileSystem._get_file() currently doesn't close the S3 response stream - such behavior leaks resources and can render subsequent calls to this method unresponsive after opening the output file failed.