### PR TITLE
Add key marker for paginated version info calls

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -887,7 +887,8 @@ class S3FileSystem(AsyncFileSystem):
             out = self.call_s3(self.s3.list_object_versions, kwargs,
                                Bucket=bucket, Prefix=key, **self.req_kw)
             versions.extend(out['Versions'])
-            kwargs['VersionIdMarker'] = out.get('NextVersionIdMarker', '')
+            kwargs.update({'VersionIdMarker': out.get('NextVersionIdMarker', ''),
+                           'KeyMarker': out.get('NextKeyMarker', '')})
         return versions
 
     _metadata_cache = {}


### PR DESCRIPTION
Hello s3fs maintainers! I ran into the same issue raised in #330. It pops up when I try to use `object_version_info` for a prefix with more versions than can fit in a single API response. This change resolves that issue.

Long-time happy user / first-time contributor here... so let me know if you have any questions/comments/etc about the change. Thanks!