### PR TITLE
Test for #378 to verify find respects maxdepth.

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -3,7 +3,6 @@ import asyncio
 import logging
 import os
 import socket
-import time
 from typing import Tuple, Optional
 import weakref
 
@@ -446,6 +445,9 @@ class S3FileSystem(AsyncFileSystem):
         bucket, key, _ = self.split_path(path)
         if not bucket:
             raise ValueError("Cannot traverse all of S3")
+        if maxdepth:
+            return super().find(bucket + "/" + key, maxdepth=maxdepth, withdirs=withdirs,
+                                detail=detail)
         # TODO: implement find from dircache, if all listings are present
         # if refresh is False:
         #     out = incomplete_tree_dirs(self.dircache, path)
@@ -481,7 +483,7 @@ class S3FileSystem(AsyncFileSystem):
             return {o['name']: o for o in out}
         return [o['name'] for o in out]
 
-    find = sync_wrapper(_find)
+    #find = sync_wrapper(_find)
 
     async def _mkdir(self, path, acl="", create_parents=True, **kwargs):
         path = self._strip_protocol(path).rstrip('/')

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -1679,3 +1679,15 @@ def test_async_close():
         await s3._s3.close()
 
     asyncio.run(_())
+
+
+def test_shallow_find(s3):
+    """Test that find method respects maxdepth.
+
+    Verify that the ``find`` method respects the ``maxdepth`` parameter.  With
+    ``maxdepth=1``, the results of ``find`` should be the same as those of
+    ``ls``, without returning subdirectories.  See also issue 378.
+    """
+
+    assert s3.ls(test_bucket_name) == s3.find(test_bucket_name, maxdepth=1)
+    assert s3.ls(test_bucket_name) == s3.glob(test_bucket_name + "/*")

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -1689,5 +1689,5 @@ def test_shallow_find(s3):
     ``ls``, without returning subdirectories.  See also issue 378.
     """
 
-    assert s3.ls(test_bucket_name) == s3.find(test_bucket_name, maxdepth=1)
+    assert s3.ls(test_bucket_name) == s3.find(test_bucket_name, maxdepth=1, withdirs=True)
     assert s3.ls(test_bucket_name) == s3.glob(test_bucket_name + "/*")


### PR DESCRIPTION
Added a test to verify that the find method respects the maxdepth
parameter.  With ``maxdepth=1``, the results of ``find`` should be
the same as those ``ls``, without returning subdirectories.  See also
issue 378.

- [x] Fixes #378
- [x] Tests added
- [ ] Tests passed