### PR TITLE
Bump GHA setup-miniconda version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Conda Environment
-        uses: conda-incubator/setup-miniconda@16930e6
+        uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
           miniconda-version: latest


### PR DESCRIPTION
setup-miniconda v2 fixes some deprecations in GitHub Actions