### PR TITLE
Handle list_object_v2 calls with missing KeyCount

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -890,7 +890,7 @@ class S3FileSystem(AsyncFileSystem):
                 MaxKeys=1,
                 **self.req_kw,
             )
-            if out["KeyCount"] > 0:
+            if out.get("KeyCount", 0) > 0 or out.get("Contents", []) or out.get("CommonPrefixes", []):
                 return {
                     "Key": "/".join([bucket, key]),
                     "name": "/".join([bucket, key]),

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -890,7 +890,11 @@ class S3FileSystem(AsyncFileSystem):
                 MaxKeys=1,
                 **self.req_kw,
             )
-            if out.get("KeyCount", 0) > 0 or out.get("Contents", []) or out.get("CommonPrefixes", []):
+            if (
+                out.get("KeyCount", 0) > 0
+                or out.get("Contents", [])
+                or out.get("CommonPrefixes", [])
+            ):
                 return {
                     "Key": "/".join([bucket, key]),
                     "name": "/".join([bucket, key]),


### PR DESCRIPTION
Some s3 server implementations such as OpenStack Object Storage
("Swift") don't provide the field KeyCount in the response to list_object_v2.

This change handles this gracefully and reverts to checking other keys
("Contents" and "CommonPrefixes").

See https://github.com/dask/s3fs/issues/404 for more details.