### PR TITLE
Butfix/issue 422 read invalid data in race condition duo to outdated filesize

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -449,16 +449,6 @@ class S3FileSystem(AsyncFileSystem):
         kwargs: dict-like
             Additional parameters used for s3 methods.  Typically used for
             ServerSideEncryption.
-
-        Exceptions
-        ----------
-        FileExpired(OSError) :
-            Is raised, when the file content has been changed from a different process after
-            opening the file. Reading the file would lead to invalid or inconsistent output.
-            This can also be triggered by outdated file-information inside the directory cache.
-            In this case ``S3FileSystem.invalidate_cache`` can be used to force an update of
-            the file-information when opening the file.
-
         """
         if block_size is None:
             block_size = self.default_block_size

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -1595,7 +1595,7 @@ class S3File(AbstractBufferedFile):
             self.loc = loc
 
         if "r" in mode:
-            self.req_kw['IfMatch'] = self.details['ETag']
+            self.req_kw["IfMatch"] = self.details["ETag"]
 
     def _call_s3(self, method, *kwarglist, **kwargs):
         return self.fs.call_s3(method, self.s3_additional_kwargs, *kwarglist, **kwargs)
@@ -1678,7 +1678,9 @@ class S3File(AbstractBufferedFile):
 
         except OSError as ex:
             if ex.args[0] == errno.EINVAL and "pre-conditions" in ex.args[1]:
-                raise FileExpired(filename=self.details['name'], e_tag=self.details['ETag']) from ex
+                raise FileExpired(
+                    filename=self.details["name"], e_tag=self.details["ETag"]
+                ) from ex
             else:
                 raise
 

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import asyncio
+import errno
 import logging
 import os
 import socket
@@ -1676,7 +1677,10 @@ class S3File(AbstractBufferedFile):
             )
 
         except OSError as ex:
-            raise FileExpired(filename=self.details['name'], e_tag=self.details['ETag']) from ex
+            if ex.args[0] == errno.EINVAL and "pre-conditions" in ex.args[1]:
+                raise FileExpired(filename=self.details['name'], e_tag=self.details['ETag']) from ex
+            else:
+                raise
 
     def _upload_chunk(self, final=False):
         bucket, key, _ = self.fs.split_path(self.path)

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -1893,7 +1893,7 @@ def test_get_file_info_with_selector(s3):
 
 
 @pytest.mark.xfail(
-    version.parse(moto.__version__) > version.parse("1.3.16"),
+    skip=version.parse(moto.__version__) > version.parse("1.3.16"),
     reason="Moto 1.3.16 is not supporting pre-conditions.",
 )
 def test_raise_exception_when_file_has_changed_during_reading(s3):

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -1189,11 +1189,19 @@ def _get_s3_id(s3):
 
 
 @pytest.mark.skipif(sys.version_info[:2] < (3, 7), reason="ctx method only >py37")
-@pytest.mark.parametrize("method",
-                         [
-                             "spawn",
-                             pytest.param("forkserver", marks=pytest.mark.skipif(sys.platform.startswith("win"), reason="'forserver' not available on windows"))
-                         ])
+@pytest.mark.parametrize(
+    "method",
+    [
+        "spawn",
+        pytest.param(
+            "forkserver",
+            marks=pytest.mark.skipif(
+                sys.platform.startswith("win"),
+                reason="'forserver' not available on windows",
+            ),
+        ),
+    ],
+)
 def test_no_connection_sharing_among_processes(s3, method):
     import multiprocessing as mp
 
@@ -1409,10 +1417,10 @@ def test_text_io__basic(s3):
     """Text mode is now allowed."""
     s3.mkdir("bucket")
 
-    with s3.open("bucket/file.txt", "w", encoding='utf-8') as fd:
+    with s3.open("bucket/file.txt", "w", encoding="utf-8") as fd:
         fd.write("\u00af\\_(\u30c4)_/\u00af")
 
-    with s3.open("bucket/file.txt", "r", encoding='utf-8') as fd:
+    with s3.open("bucket/file.txt", "r", encoding="utf-8") as fd:
         assert fd.read() == "\u00af\\_(\u30c4)_/\u00af"
 
 

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import asyncio
+import errno
 import datetime
 from contextlib import contextmanager
 import json
@@ -83,13 +84,17 @@ def s3_base():
     proc.wait()
 
 
-@pytest.fixture()
-def s3(s3_base):
+def get_boto3_client():
     from botocore.session import Session
 
     # NB: we use the sync botocore client for setup
     session = Session()
-    client = session.create_client("s3", endpoint_url=endpoint_uri)
+    return session.create_client("s3", endpoint_url=endpoint_uri)
+
+
+@pytest.fixture()
+def s3(s3_base):
+    client = get_boto3_client()
     client.create_bucket(Bucket=test_bucket_name, ACL="public-read")
 
     client.create_bucket(Bucket=versioned_bucket_name, ACL="public-read")
@@ -1883,3 +1888,26 @@ def test_get_file_info_with_selector(s3):
                 raise ValueError("unexpected path {}".format(info["name"]))
     finally:
         fs.rm(base_dir, recursive=True)
+
+
+def test_raise_exception_when_file_has_changed_during_reading(s3):
+    test_file_name = "file1"
+    test_file = "s3://" + test_bucket_name + "/" + test_file_name
+    content1 = b"123"
+    content2 = b"ABCDEFG"
+
+    boto3_client = get_boto3_client()
+
+    def create_file(content: bytes):
+        boto3_client.put_object(Bucket=test_bucket_name, Key=test_file_name, Body=content)
+
+    create_file(b"123")
+
+    with s3.open(test_file, "rb") as f:
+        content = f.read()
+        assert content == content1
+
+    with s3.open(test_file, "rb") as f:
+        create_file(content2)
+        with expect_errno(errno.EBUSY):
+            f.read()

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -1899,7 +1899,9 @@ def test_raise_exception_when_file_has_changed_during_reading(s3):
     boto3_client = get_boto3_client()
 
     def create_file(content: bytes):
-        boto3_client.put_object(Bucket=test_bucket_name, Key=test_file_name, Body=content)
+        boto3_client.put_object(
+            Bucket=test_bucket_name, Key=test_file_name, Body=content
+        )
 
     create_file(b"123")
 

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -1893,7 +1893,7 @@ def test_get_file_info_with_selector(s3):
 
 
 @pytest.mark.xfail(
-    skip=version.parse(moto.__version__) > version.parse("1.3.16"),
+    condition=version.parse(moto.__version__) <= version.parse("1.3.16"),
     reason="Moto 1.3.16 is not supporting pre-conditions.",
 )
 def test_raise_exception_when_file_has_changed_during_reading(s3):

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -1405,10 +1405,10 @@ def test_text_io__basic(s3):
     """Text mode is now allowed."""
     s3.mkdir("bucket")
 
-    with s3.open("bucket/file.txt", "w") as fd:
+    with s3.open("bucket/file.txt", "w", encoding='utf-8') as fd:
         fd.write("\u00af\\_(\u30c4)_/\u00af")
 
-    with s3.open("bucket/file.txt", "r") as fd:
+    with s3.open("bucket/file.txt", "r", encoding='utf-8') as fd:
         assert fd.read() == "\u00af\\_(\u30c4)_/\u00af"
 
 

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -1892,7 +1892,10 @@ def test_get_file_info_with_selector(s3):
         fs.rm(base_dir, recursive=True)
 
 
-@pytest.mark.xfail(version.parse(moto.__version__) > version.parse("1.3.16"))
+@pytest.mark.xfail(
+    version.parse(moto.__version__) > version.parse("1.3.16"),
+    reason="Moto 1.3.16 is not supporting pre-conditions.",
+)
 def test_raise_exception_when_file_has_changed_during_reading(s3):
     test_file_name = "file1"
     test_file = "s3://" + test_bucket_name + "/" + test_file_name

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -1189,7 +1189,11 @@ def _get_s3_id(s3):
 
 
 @pytest.mark.skipif(sys.version_info[:2] < (3, 7), reason="ctx method only >py37")
-@pytest.mark.parametrize("method", ["spawn", "forkserver"])
+@pytest.mark.parametrize("method",
+                         [
+                             "spawn",
+                             pytest.param("forkserver", marks=pytest.mark.skipif(sys.platform.startswith("win"), reason="'forserver' not available on windows"))
+                         ])
 def test_no_connection_sharing_among_processes(s3, method):
     import multiprocessing as mp
 

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -11,12 +11,14 @@ import requests
 import time
 import sys
 import pytest
+import moto
 from itertools import chain
 import fsspec.core
 from s3fs.core import S3FileSystem
 from s3fs.utils import ignoring, SSEParams
 from botocore.exceptions import NoCredentialsError
 from fsspec.asyn import sync
+from packaging import version
 
 test_bucket_name = "test"
 secure_bucket_name = "test-secure"
@@ -1890,6 +1892,7 @@ def test_get_file_info_with_selector(s3):
         fs.rm(base_dir, recursive=True)
 
 
+@pytest.mark.xfail(version.parse(moto.__version__) > version.parse("1.3.16"))
 def test_raise_exception_when_file_has_changed_during_reading(s3):
     test_file_name = "file1"
     test_file = "s3://" + test_bucket_name + "/" + test_file_name

--- a/s3fs/utils.py
+++ b/s3fs/utils.py
@@ -12,7 +12,11 @@ def ignoring(*exceptions):
 
 class FileExpired(IOError):
     def __init__(self, filename: str, e_tag: str):
-        super().__init__(errno.EBUSY, "The remote file corresponding to filename %s and Etag %s no longer exists." % (filename, e_tag))
+        super().__init__(
+            errno.EBUSY,
+            "The remote file corresponding to filename %s and Etag %s no longer exists."
+            % (filename, e_tag),
+        )
 
 
 def title_case(string):

--- a/s3fs/utils.py
+++ b/s3fs/utils.py
@@ -1,3 +1,4 @@
+import errno
 from contextlib import contextmanager
 
 
@@ -7,6 +8,11 @@ def ignoring(*exceptions):
         yield
     except exceptions:
         pass
+
+
+class FileExpired(IOError):
+    def __init__(self, filename: str, e_tag: str):
+        super().__init__(errno.EBUSY, "The remote file corresponding to filename %s and Etag %s no longer exists." % (filename, e_tag))
 
 
 def title_case(string):

--- a/s3fs/utils.py
+++ b/s3fs/utils.py
@@ -11,6 +11,13 @@ def ignoring(*exceptions):
 
 
 class FileExpired(IOError):
+    """
+    Is raised, when the file content has been changed from a different process after
+    opening the file. Reading the file would lead to invalid or inconsistent output.
+    This can also be triggered by outdated file-information inside the directory cache.
+    In this case ``S3FileSystem.invalidate_cache`` can be used to force an update of
+    the file-information when opening the file.
+    """
     def __init__(self, filename: str, e_tag: str):
         super().__init__(
             errno.EBUSY,

--- a/s3fs/utils.py
+++ b/s3fs/utils.py
@@ -18,6 +18,7 @@ class FileExpired(IOError):
     In this case ``S3FileSystem.invalidate_cache`` can be used to force an update of
     the file-information when opening the file.
     """
+
     def __init__(self, filename: str, e_tag: str):
         super().__init__(
             errno.EBUSY,

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,6 @@
 mock; python_version < '3.3'
 moto>=1.3.7
+flask
+botocore>=1.19.52,<1.19.53
 pytest>=4.2.0
 pytest-env


### PR DESCRIPTION
**Attention: Branch is based on PR https://github.com/dask/s3fs/pull/427, please merge this before**

This pull-request addresses the issue https://github.com/dask/s3fs/issues/422.

It introduces a pre-condition for file-reads to check, if the ETag has been changed since reading the file-size. It works with S3 buckets, but not with the S3 Bucket mock `moto` version 1.3.16, since `moto` does not provide a pre-condition check in this version.

The pre-condition check is already on the master banch of moto and when installed the development version from moto locally, the corresponding test passes. However we still need to wait until the next release of moto.

See also the request for the next release here: https://github.com/spulec/moto/issues/3712