### PR TITLE
Allow for zero start in _cat_file

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -734,7 +734,7 @@ class S3FileSystem(AsyncFileSystem):
         bucket, key, vers = self.split_path(path)
         if (start is None) ^ (end is None):
             raise ValueError("Give start and end or neither")
-        if start:
+        if start is not None:
             head = {"Range": "bytes=%i-%i" % (start, end - 1)}
         else:
             head = {}

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -1745,6 +1745,8 @@ def test_async_s3(s3):
 
         assert await s3._cat_file(fn) == data
 
+        assert await s3._cat_file(fn, start=0, end=3) == data[:3]
+
         with s3.open(fn, "rb") as f:
             assert f.read() == data
 


### PR DESCRIPTION
Fixes #433

I created the test first and verified that it failed without the fix in `_cat_file`.