### PR TITLE
setup: pin moto to under 2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install dependencies
         shell: bash -l {0}
         run: |
-          conda install -c conda-forge pip botocore aiobotocore moto pytest flake8 black -y
+          conda install -c conda-forge pip botocore aiobotocore "moto<2.0" pytest flake8 black -y
           pip install git+https://github.com/intake/filesystem_spec --no-deps
           conda list
           conda --version

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,5 +1,5 @@
 mock; python_version < '3.3'
-moto>=1.3.7
+moto>=1.3.7,<2.0.0
 flask
 pytest>=4.2.0
 pytest-env


### PR DESCRIPTION
I didn't had chance to debug it fully though moto>2.0 is incompatible with the tests as is (2 version check tests are failing) intake/filesystem_spec/pull/557