### PR TITLE
Rename _connect to set_session

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -100,8 +100,9 @@ await the client creation before making any S3 call.
 
     async def run_program():
         s3 = S3FileSystem(..., asynchronous=True)
-        await s3._connect()
+        session = await s3.set_session()
         ...  # perform work
+        await session.close()
 
     asyncio.run(run_program())  # or call from your async code
 

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -377,8 +377,7 @@ class S3FileSystem(AsyncFileSystem):
         self._kwargs_helper = ParamKwargsHelper(self._s3)
         return self._s3
 
-    async def _connect(self, refresh=False, kwargs={}):
-        return await self.set_session(refresh=refresh, **kwargs)
+    _connect = set_session
 
     connect = sync_wrapper(set_session)
 


### PR DESCRIPTION
Fixes #454 

This renames `_connect` to `set_session` and provides an implementation of `_connect` for backward compatibility. The documentation are tests are updated, too.

