### PR TITLE
Docs: Change env variables to upper case

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -146,7 +146,7 @@ A more secure way, not including the credentials directly in code, is to allow
 boto to establish the credentials automatically. Boto will try the following
 methods, in order:
 
-- ``aws_access_key_id``, ``aws_secret_access_key``, and ``aws_session_token``
+- ``AWS_ACCESS_KEY_ID``, ``AWS_SECRET_ACCESS_KEY``, and ``AWS_SESSION_TOKEN``
   environment variables
 
 - configuration files such as ``~/.aws/credentials``


### PR DESCRIPTION
Per the [`boto3` docs](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#environment-variables), the environment variables for credentials need to be uppercase. If I set lowercase env variables on my machine (OSX), I get the a `NoCredentialsError: Unable to locate credentials`.