### PR TITLE
fix import error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 aiobotocore>=1.0.1
-fsspec>=0.8.0
+fsspec>=0.9.0

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -8,7 +8,7 @@ from typing import Tuple, Optional
 import weakref
 
 from fsspec.spec import AbstractBufferedFile
-from fsspec.utils import infer_storage_options, tokenize, setup_logging
+from fsspec.utils import infer_storage_options, tokenize, setup_logging as setup_logger
 from fsspec.asyn import AsyncFileSystem, sync, sync_wrapper
 
 import aiobotocore
@@ -20,21 +20,18 @@ from botocore.exceptions import ClientError, ParamValidationError
 from s3fs.errors import translate_boto_error
 from s3fs.utils import ParamKwargsHelper, _get_brange, FileExpired
 
+
 logger = logging.getLogger("s3fs")
 
 
 def setup_logging(level=None):
-    handle = logging.StreamHandler()
-    formatter = logging.Formatter(
-        "%(asctime)s - %(name)s - %(levelname)s " "- %(message)s"
-    )
-    handle.setFormatter(formatter)
-    logger.addHandler(handle)
-    logger.setLevel(level or os.environ["S3FS_LOGGING_LEVEL"])
+
+    setup_logger(logger=logger, level=(level or os.environ["S3FS_LOGGING_LEVEL"]))
 
 
 if "S3FS_LOGGING_LEVEL" in os.environ:
     setup_logging()
+
 
 MANAGED_COPY_THRESHOLD = 5 * 2 ** 30
 S3_RETRYABLE_ERRORS = (socket.timeout,)


### PR DESCRIPTION
`fsspec.utils.setup_logging` doesn't appear to be used anywhere in s3fs.core (it's redefined almost immediately after the import). 

`fsspec==0.9.0` has the function `fsspec.utils.setup_logging` but earlier versions do not (it was renamed from setup_logger->setup_logging in `0.9.0`). The tests for `main` seem to be passing on `fsspec>=0.9.0` but the install requirements have `fsspec>=0.8.0`. It seems like the options are either bump the fsspec version to 0.9.0 or remove the unused import. 

I'm happy to make any necessary changes. 