### PR TITLE
allow None etag, and do not set IfMatch as a result.

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -1752,8 +1752,9 @@ class S3File(AbstractBufferedFile):
                 self.append_block = True
             self.loc = loc
 
-        if "r" in mode:
-            self.req_kw["IfMatch"] = self.details["ETag"]
+        e_tag = self.details.get("ETag")
+        if "r" in mode and e_tag is not None:
+            self.req_kw["IfMatch"] = e_tag
 
     def _call_s3(self, method, *kwarglist, **kwargs):
         return self.fs.call_s3(method, self.s3_additional_kwargs, *kwarglist, **kwargs)


### PR DESCRIPTION
This PR addresses the issue elaborated on here: https://github.com/dask/s3fs/issues/477, which was causing s3fs to fail when no ETag was available for an s3 object.

Let me know if you guys want a specific unit test for this -- it's such a minor change that I'm not sure whether it warrants one.

Fixes #477