### PR TITLE
cast all non-truthy prefixes to an empty string

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -549,6 +549,8 @@ class S3FileSystem(AsyncFileSystem):
         self, path, refresh=False, max_items=None, delimiter="/", prefix=""
     ):
         bucket, key, _ = self.split_path(path)
+        if not prefix:
+            prefix = ""
         if key:
             prefix = key.lstrip("/") + "/" + prefix
         if path not in self.dircache or refresh or not delimiter:

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -2140,6 +2140,7 @@ def test_find_with_prefix(s3):
     assert test_1s == [test_bucket_name + "/prefixes/test_1"] + [
         test_bucket_name + f"/prefixes/test_{cursor}" for cursor in range(10, 20)
     ]
+    assert s3.find(test_bucket_name + "/prefixes/") == s3.find(test_bucket_name + "/prefixes/", prefix=None)
 
 
 def test_list_after_find(s3):

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -2140,7 +2140,9 @@ def test_find_with_prefix(s3):
     assert test_1s == [test_bucket_name + "/prefixes/test_1"] + [
         test_bucket_name + f"/prefixes/test_{cursor}" for cursor in range(10, 20)
     ]
-    assert s3.find(test_bucket_name + "/prefixes/") == s3.find(test_bucket_name + "/prefixes/", prefix=None)
+    assert s3.find(test_bucket_name + "/prefixes/") == s3.find(
+        test_bucket_name + "/prefixes/", prefix=None
+    )
 
 
 def test_list_after_find(s3):


### PR DESCRIPTION
Now it supports `.find(prefix=None)` 