### PR TITLE
Aio session is no longer top level

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-aiobotocore>=1.0.1
+aiobotocore~=1.4.0
 fsspec==2021.07.0

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -133,7 +133,7 @@ class S3FileSystem(AsyncFileSystem):
     kwargs : other parameters for core session
     session : aiobotocore AioSession object to be used for all connections.
          This session will be used inplace of creating a new session inside S3FileSystem.
-         For example: aiobotocore.AioSession(profile='test_user')
+         For example: aiobotocore.session.AioSession(profile='test_user')
 
     The following parameters are passed on to fsspec:
 
@@ -376,7 +376,7 @@ class S3FileSystem(AsyncFileSystem):
 
         conf = AioConfig(**config_kwargs)
         if self.session is None:
-            self.session = aiobotocore.AioSession(**self.kwargs)
+            self.session = aiobotocore.session.AioSession(**self.kwargs)
 
         for parameters in (config_kwargs, self.kwargs, init_kwargs, client_kwargs):
             for option in ("region_name", "endpoint_url"):

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,14 @@
 from setuptools import setup
 import versioneer
 
+with open('requirements.txt') as file:
+    aiobotocore_version_suffix = ''
+    for line in file:
+        parts = line.rstrip().split('aiobotocore')
+        if len(parts) == 2:
+            aiobotocore_version_suffix = parts[1]
+            break
+
 setup(name='s3fs',
       version=versioneer.get_version(),
       cmdclass=versioneer.get_cmdclass(),
@@ -25,8 +33,8 @@ setup(name='s3fs',
       packages=['s3fs'],
       python_requires='>= 3.6',
       install_requires=[open('requirements.txt').read().strip().split('\n')],
-      extras_require = {
-          'awscli': ['aiobotocore[awscli]'],
-          'boto3': ['aiobotocore[boto3]'],
+      extras_require={
+          'awscli': [f"aiobotocore[awscli]{aiobotocore_version_suffix}"],
+          'boto3': [f"aiobotocore[boto3]{aiobotocore_version_suffix}"],
       },
       zip_safe=False)


### PR DESCRIPTION
Since https://github.com/aio-libs/aiobotocore/releases/tag/1.4.0, `AioSession` no longer exists in the top-level namespace. This PR also:

- pins the **aiobotocore** dependency more strictly, since the project demonstrated that it will do backwards-incompatible changes with a minor bump, and
- pins the `extras_require` dependencies; they were previously unpinned.

My local test runs are failing but I _don't_ think its due to this change (they were failing on **main**) so apologies if CI fails.