### PR TITLE
made glob raise exception on *

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -602,6 +602,11 @@ class S3FileSystem(AsyncFileSystem):
             return files
         return self.dircache[path]
 
+    async def _glob(self, path, **kwargs):
+        if path.startswith("*"):
+            raise ValueError("Cannot traverse all of S3")
+        return await super()._glob(path, **kwargs)
+
     async def _find(self, path, maxdepth=None, withdirs=None, detail=False, prefix=""):
         """List all files below path.
         Like posix ``find`` command without conditions


### PR DESCRIPTION
Hej hej!

Currently the expected behavior of `glob("*")` is to throw an exception.

But this behavior currently relies on private implementation details of `fsspec` which are orthogonal to `s3fs`.

This pull request removes this implicit dependency, so that both projects can continue to develop in parallel.