### PR TITLE
Add IncompleteRead to a set of retryable errors

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -7,6 +7,8 @@ import socket
 from typing import Tuple, Optional
 import weakref
 
+from urllib3.exceptions import IncompleteRead
+
 from fsspec.spec import AbstractBufferedFile
 from fsspec.utils import infer_storage_options, tokenize, setup_logging as setup_logger
 from fsspec.asyn import AsyncFileSystem, sync, sync_wrapper, FSTimeoutError
@@ -34,7 +36,7 @@ if "S3FS_LOGGING_LEVEL" in os.environ:
 
 
 MANAGED_COPY_THRESHOLD = 5 * 2 ** 30
-S3_RETRYABLE_ERRORS = (socket.timeout,)
+S3_RETRYABLE_ERRORS = (socket.timeout, IncompleteRead)
 
 _VALID_FILE_MODES = {"r", "w", "a", "rb", "wb", "ab"}
 


### PR DESCRIPTION
Addresses the #issue 194. S3fs propagates IncompleteRead error when the network is flaky. 

This error was previously removed by large:
https://github.com/boto/boto3/commit/d02dc9b57ae28ccb2265dcf1e560afd7dbad8098#diff-6e0c1dbf251dce0fe05f05e3dc7645cdL150

Not sure if it was intentional. 