### PR TITLE
Remove redundant `self` argument from `_rm_versioned_bucket_contents` call

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -1674,7 +1674,7 @@ class S3FileSystem(AsyncFileSystem):
             bucket, key, _ = self.split_path(path)
             if not key and await self._is_bucket_versioned(bucket):
                 # special path to completely remove versioned bucket
-                await self._rm_versioned_bucket_contents(self, bucket)
+                await self._rm_versioned_bucket_contents(bucket)
         paths = await self._expand_path(path, recursive=recursive)
         files = [p for p in paths if self.split_path(p)[1]]
         dirs = [p for p in paths if not self.split_path(p)[1]]


### PR DESCRIPTION
In the special case of completely clearing a versioned bucket, I ran into this error:

```
TypeError: _rm_versioned_bucket_contents() takes 2 positional arguments but 3 were given
```

This yanks the extra `self` so that call can succeed.