### PR TITLE
Set cache_regions to True by default

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -899,6 +899,7 @@ class S3FileSystem(AsyncFileSystem):
     makedirs = sync_wrapper(_makedirs)
 
     async def _rmdir(self, path):
+        path = self._strip_protocol(path).rstrip("/")
         if "/" in path:
             if await self._exists(path):
                 # did you mean rm(path, recursive=True) ?


### PR DESCRIPTION
This seems to solve a number of aiobotocore redirect access issues, and aside from complexity, I don't see a downside.