### PR TITLE
Fix code-block whitespace doc build error

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -210,6 +210,7 @@ For a self-hosted MinIO instance:
 It is also possible to set credentials through envrironment variables:
 
 .. code-block:: python
+
    # export FSSPEC_S3_ENDPOINT_URL=https://...
    # export FSSPEC_S3_KEY='miniokey...'
    # export FSSPEC_S3_SECRET='asecretkey...'


### PR DESCRIPTION
This fixes the latest doc build error https://readthedocs.org/api/v2/build/19997774.txt:

```
/home/docs/checkouts/readthedocs.org/user_builds/s3fs/checkouts/713/docs/source/index.rst:212: ERROR: Error in "code-block" directive:
maximum 1 argument(s) allowed, 21 supplied.

.. code-block:: python
   # export FSSPEC_S3_ENDPOINT_URL=https://...
   # export FSSPEC_S3_KEY='miniokey...'
   # export FSSPEC_S3_SECRET='asecretkey...'
   >>> s3 = s3fs.S3FileSystem()
   # or ...
   >>> f = fsspec.open("s3://minio-bucket/...")
```

The fix is to add a line of whitespace after the `code-block` directive.