### PR TITLE
Skip the current directory entity when running 'ls' or 'listdir'

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -813,7 +813,7 @@ class S3FileSystem(AsyncFileSystem):
                 self._fill_info(c, bucket, versions=False)
                 yield c
             for c in i.get(contents_key, []):
-                if c["Size"] == 0 and c["Key"] == i["Prefix"]:
+                if c["Size"] == 0 and c["Key"] == i.get("Prefix", ""):
                     continue  # skip an entity that is the current directory
                 if not self.version_aware or c.get("IsLatest") or versions:
                     c["type"] = "file"


### PR DESCRIPTION
When using `S3FileSystem.ls` or `S3FileSystem.listdir`, zero-sized objects that serve as directory markers in S3 were incorrectly listed as files.

Amazon S3 employs a flat object storage model, but its console interface allows users to create "folders" by adding zero-size objects with keys ending in a delimiter (e.g., `myfolder/`). These objects act as placeholders to visually represent directories but are not actual files.

This PR implements a check to skip zero-size objects that match the current directory prefix during listing operations.