### PR TITLE
Allow anonymous access to be configured by an environment variable

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -243,7 +243,8 @@ also has the appropriate environment variables, config files or IAM roles
 available.
 
 If none of the credential methods are available, only anonymous access will
-work, and ``anon=True`` must be passed to the constructor.
+work, and ``anon=True`` must be passed to the constructor (or the environment
+variable ``S3FS_ANONYMOUS`` set to ``True`` or ``1``).
 
 Furthermore, :py:meth:`.S3FileSystem.current` will return the most-recently created
 instance, so this method could be used in preference to the constructor in

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -268,10 +268,12 @@ class S3FileSystem(AsyncFileSystem):
 
     Parameters
     ----------
-    anon : bool (False)
+    anon : bool or None (None)
         Whether to use anonymous connection (public buckets only). If False,
         uses the key/secret given, or boto's credential resolver (client_kwargs,
-        environment, variables, config files, EC2 IAM server, in that order)
+        environment, variables, config files, EC2 IAM server, in that order). If None,
+        this option will be set to True if the environment variable S3FS_ANONYMOUS
+        is set to true, True, t, T, or 1.
     endpoint_url : string (None)
         Use this endpoint_url, if specified. Needed for connecting to non-AWS
         S3 buckets. Takes precedence over `endpoint_url` in client_kwargs.
@@ -366,7 +368,7 @@ class S3FileSystem(AsyncFileSystem):
 
     def __init__(
         self,
-        anon=False,
+        anon=None,
         endpoint_url=None,
         key=None,
         secret=None,
@@ -402,6 +404,8 @@ class S3FileSystem(AsyncFileSystem):
 
         self.endpoint_url = endpoint_url
 
+        if anon is None:
+            anon = os.getenv("S3FS_ANONYMOUS", "False").lower() in ("1", "true", "t")
         self.anon = anon
         self.key = key
         self.secret = secret

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -3217,5 +3217,13 @@ def test_rm_recursive_prfix(s3):
 def test_anonymous_from_environment_variable(value, expected, monkeypatch):
     monkeypatch.setenv("S3FS_ANONYMOUS", value)
     s = s3fs.S3FileSystem()
-    assert s.anon == expected
     S3FileSystem.clear_instance_cache()
+    assert s.anon == expected
+
+
+@pytest.mark.parametrize("value", [True, False])
+def test_anon_overrides_environment_variable(value, monkeypatch):
+    monkeypatch.setenv("S3FS_ANONYMOUS", str(not value))
+    s = s3fs.S3FileSystem(anon=value)
+    S3FileSystem.clear_instance_cache()
+    assert s.anon == value

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -3198,3 +3198,24 @@ def test_rm_recursive_prfix(s3):
     logs_path = f"s3://{test_bucket_name}/{prefix}"
     s3.rm(logs_path, recursive=True)
     assert not s3.isdir(logs_path)
+
+
+@pytest.mark.parametrize("value, expected", [
+    ("True", True),
+    ("true", True),
+    ("TRUE", True),
+    ("t", True),
+    ("T", True),
+    ("1", True),
+    ("a", False),
+    ("False", False),
+    ("false", False),
+    ("FALSE", False),
+    ("f", False),
+    ("F", False),
+])
+def test_anonymous_from_environment_variable(value, expected, monkeypatch):
+    monkeypatch.setenv("S3FS_ANONYMOUS", value)
+    s = s3fs.S3FileSystem()
+    assert s.anon == expected
+    S3FileSystem.clear_instance_cache()


### PR DESCRIPTION
Closes https://github.com/fsspec/s3fs/issues/675

Add support for reading an environment variable `S3FS_ANONYMOUS` when a value for `anon` is not provided to `S3FileSystem.__init__`.