### PR TITLE
fix: close stale S3BucketRegionCache on session refresh; guard _sessions=None; serialize set_session() under asyncio.Lock

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -9,7 +9,11 @@ Unreleased
   connections mid-session (#NNNN)
 - guard stale-session check against ``_sessions = None`` (newer aiobotocore
   sets ``_sessions`` to ``None`` after close rather than leaving it as an
-  empty dict) (#NNNN)
+  empty dict) and against empty ``_sessions`` (no requests yet, not stale)
+  (#NNNN)
+- serialize ``set_session()`` creator setup under an ``asyncio.Lock`` to
+  prevent concurrent callers (e.g. ``asyncio.gather``) from each creating a
+  separate creator and then closing each other's in-flight sessions (#NNNN)
 
 2026.4.0
 --------

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -7,9 +7,9 @@ Unreleased
 - close stale ``S3BucketRegionCache`` on session refresh, eliminating
   ``aiohttp`` "Unclosed client session" warnings when the server closes
   connections mid-session (#NNNN)
-- add ``_close()`` / ``close()`` to ``S3FileSystem`` for deterministic
-  resource cleanup; previously cleanup relied entirely on garbage collection
-  via ``weakref.finalize`` (#NNNN)
+- guard stale-session check against ``_sessions = None`` (newer aiobotocore
+  sets ``_sessions`` to ``None`` after close rather than leaving it as an
+  empty dict) (#NNNN)
 
 2026.4.0
 --------

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+- close stale ``S3BucketRegionCache`` on session refresh, eliminating
+  ``aiohttp`` "Unclosed client session" warnings when the server closes
+  connections mid-session (#NNNN)
+- add ``_close()`` / ``close()`` to ``S3FileSystem`` for deterministic
+  resource cleanup; previously cleanup relied entirely on garbage collection
+  via ``weakref.finalize`` (#NNNN)
+
 2026.4.0
 --------
 

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -600,96 +600,115 @@ class S3FileSystem(AsyncFileSystem):
             hsess = getattr(getattr(self._s3, "_endpoint", None), "http_session", None)
             if hsess is not None:
                 sessions = hsess._sessions  # None after __aexit__ in newer aiobotocore
-                if sessions is not None and all(_.closed for _ in sessions.values()):
+                # Only refresh when sessions exist AND all are server-closed.
+                # An empty dict means no requests have been sent yet — not stale.
+                if sessions is not None and sessions and all(_.closed for _ in sessions.values()):
                     refresh = True
             if not refresh:
                 return self._s3
-        logger.debug("Setting up s3fs instance")
 
-        client_kwargs = self.client_kwargs.copy()
-        init_kwargs = dict(
-            aws_access_key_id=self.key,
-            aws_secret_access_key=self.secret,
-            aws_session_token=self.token,
-            endpoint_url=self.endpoint_url,
-        )
-        init_kwargs = {
-            key: value
-            for key, value in init_kwargs.items()
-            if value is not None and value != client_kwargs.get(key)
-        }
-        if "use_ssl" not in client_kwargs.keys():
-            init_kwargs["use_ssl"] = self.use_ssl
-        config_kwargs = self._prepare_config_kwargs()
-        if self.anon:
-            from botocore import UNSIGNED
+        # Serialize creator setup.  Callers such as zarr may launch concurrent
+        # coroutines via asyncio.gather that all see self._s3 is None and each
+        # try to build their own creator.  Without this lock every concurrent
+        # task would create a separate creator and then Fix 1 (close stale
+        # creator) would tear down a creator that a sibling task is still using,
+        # causing ``_sessions = None`` mid-request.  asyncio.Lock is
+        # event-loop–aware; creating it between two non-await lines is atomic
+        # so there is no race on the hasattr check.
+        if not hasattr(self, "_setup_lock"):
+            self._setup_lock = asyncio.Lock()
+        async with self._setup_lock:
+            # Re-check under the lock: a concurrent task may have set up the
+            # session while we were waiting.
+            if self._s3 is not None and not refresh:
+                return self._s3
 
-            drop_keys = {
-                "aws_access_key_id",
-                "aws_secret_access_key",
-                "aws_session_token",
-            }
+            logger.debug("Setting up s3fs instance")
+
+            client_kwargs = self.client_kwargs.copy()
+            init_kwargs = dict(
+                aws_access_key_id=self.key,
+                aws_secret_access_key=self.secret,
+                aws_session_token=self.token,
+                endpoint_url=self.endpoint_url,
+            )
             init_kwargs = {
-                key: value for key, value in init_kwargs.items() if key not in drop_keys
-            }
-            client_kwargs = {
                 key: value
-                for key, value in client_kwargs.items()
-                if key not in drop_keys
+                for key, value in init_kwargs.items()
+                if value is not None and value != client_kwargs.get(key)
             }
-            config_kwargs["signature_version"] = UNSIGNED
+            if "use_ssl" not in client_kwargs.keys():
+                init_kwargs["use_ssl"] = self.use_ssl
+            config_kwargs = self._prepare_config_kwargs()
+            if self.anon:
+                from botocore import UNSIGNED
 
-        conf = AioConfig(**config_kwargs)
-        if self.session is None or refresh:
-            self.session = aiobotocore.session.AioSession(**self.kwargs)
+                drop_keys = {
+                    "aws_access_key_id",
+                    "aws_secret_access_key",
+                    "aws_session_token",
+                }
+                init_kwargs = {
+                    key: value for key, value in init_kwargs.items() if key not in drop_keys
+                }
+                client_kwargs = {
+                    key: value
+                    for key, value in client_kwargs.items()
+                    if key not in drop_keys
+                }
+                config_kwargs["signature_version"] = UNSIGNED
 
-        for parameters in (config_kwargs, self.kwargs, init_kwargs, client_kwargs):
-            for option in ("region_name", "endpoint_url"):
-                if parameters.get(option):
-                    self.cache_regions = False
-                    break
-        else:
-            cache_regions = self.cache_regions
+            conf = AioConfig(**config_kwargs)
+            if self.session is None or refresh:
+                self.session = aiobotocore.session.AioSession(**self.kwargs)
 
-        logger.debug(
-            "RC: caching enabled? %r (explicit option is %r)",
-            cache_regions,
-            self.cache_regions,
-        )
-        self.cache_regions = cache_regions
-        if self.cache_regions:
-            s3creator = S3BucketRegionCache(
-                self.session, config=conf, **init_kwargs, **client_kwargs
+            for parameters in (config_kwargs, self.kwargs, init_kwargs, client_kwargs):
+                for option in ("region_name", "endpoint_url"):
+                    if parameters.get(option):
+                        self.cache_regions = False
+                        break
+            else:
+                cache_regions = self.cache_regions
+
+            logger.debug(
+                "RC: caching enabled? %r (explicit option is %r)",
+                cache_regions,
+                self.cache_regions,
             )
-            self._s3 = await s3creator.get_client()
-        else:
-            s3creator = self.session.create_client(
-                "s3", config=conf, **init_kwargs, **client_kwargs
-            )
-            self._s3 = await s3creator.__aenter__()
+            self.cache_regions = cache_regions
+            if self.cache_regions:
+                s3creator = S3BucketRegionCache(
+                    self.session, config=conf, **init_kwargs, **client_kwargs
+                )
+                self._s3 = await s3creator.get_client()
+            else:
+                s3creator = self.session.create_client(
+                    "s3", config=conf, **init_kwargs, **client_kwargs
+                )
+                self._s3 = await s3creator.__aenter__()
 
-        # Close the stale _s3creator before replacing it.  The old cache holds
-        # aiobotocore ClientSessions that are garbage-collected without an
-        # explicit close(), causing aiohttp "Unclosed client session" warnings.
-        # See: https://github.com/aio-libs/aiobotocore/issues/866
-        old_creator = getattr(self, "_s3creator", None)
-        if old_creator is not None:
-            try:
-                await old_creator.__aexit__(None, None, None)
-            except Exception:
-                pass
-        self._s3creator = s3creator
-        # the following actually closes the aiohttp connection; use of privates
-        # might break in the future, would cause exception at gc time
-        if not self.asynchronous:
-            old_finalizer = getattr(self, "_finalizer", None)
-            if old_finalizer is not None:
-                old_finalizer.detach()
-            self._finalizer = weakref.finalize(
-                self, self.close_session, self.loop, self._s3creator
-            )
-        self._kwargs_helper = ParamKwargsHelper(self._s3)
-        return self._s3
+            # Close the stale _s3creator before replacing it.  The old cache holds
+            # aiobotocore ClientSessions that are garbage-collected without an
+            # explicit close(), causing aiohttp "Unclosed client session" warnings.
+            # See: https://github.com/aio-libs/aiobotocore/issues/866
+            old_creator = getattr(self, "_s3creator", None)
+            if old_creator is not None:
+                try:
+                    await old_creator.__aexit__(None, None, None)
+                except Exception:
+                    pass
+            self._s3creator = s3creator
+            # the following actually closes the aiohttp connection; use of privates
+            # might break in the future, would cause exception at gc time
+            if not self.asynchronous:
+                old_finalizer = getattr(self, "_finalizer", None)
+                if old_finalizer is not None:
+                    old_finalizer.detach()
+                self._finalizer = weakref.finalize(
+                    self, self.close_session, self.loop, self._s3creator
+                )
+            self._kwargs_helper = ParamKwargsHelper(self._s3)
+            return self._s3
 
     _connect = set_session
 

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -616,6 +616,43 @@ class S3FileSystem(AsyncFileSystem):
         # task would create a separate creator and then Fix 1 (close stale
         # creator) would tear down a creator that a sibling task is still using,
         # causing ``_sessions = None`` mid-request.
+        # Compute kwargs before the lock — pure reads, no awaits, safe to
+        # redo if another coroutine wins the race and we return early inside.
+        client_kwargs = self.client_kwargs.copy()
+        init_kwargs = dict(
+            aws_access_key_id=self.key,
+            aws_secret_access_key=self.secret,
+            aws_session_token=self.token,
+            endpoint_url=self.endpoint_url,
+        )
+        init_kwargs = {
+            key: value
+            for key, value in init_kwargs.items()
+            if value is not None and value != client_kwargs.get(key)
+        }
+        if "use_ssl" not in client_kwargs.keys():
+            init_kwargs["use_ssl"] = self.use_ssl
+        config_kwargs = self._prepare_config_kwargs()
+        if self.anon:
+            from botocore import UNSIGNED
+
+            drop_keys = {
+                "aws_access_key_id",
+                "aws_secret_access_key",
+                "aws_session_token",
+            }
+            init_kwargs = {
+                key: value for key, value in init_kwargs.items() if key not in drop_keys
+            }
+            client_kwargs = {
+                key: value
+                for key, value in client_kwargs.items()
+                if key not in drop_keys
+            }
+            config_kwargs["signature_version"] = UNSIGNED
+
+        conf = AioConfig(**config_kwargs)
+
         async with self._setup_lock:
             # Re-check under the lock: a concurrent task may have set up the
             # session while we were waiting.
@@ -624,42 +661,6 @@ class S3FileSystem(AsyncFileSystem):
 
             logger.debug("Setting up s3fs instance")
 
-            client_kwargs = self.client_kwargs.copy()
-            init_kwargs = dict(
-                aws_access_key_id=self.key,
-                aws_secret_access_key=self.secret,
-                aws_session_token=self.token,
-                endpoint_url=self.endpoint_url,
-            )
-            init_kwargs = {
-                key: value
-                for key, value in init_kwargs.items()
-                if value is not None and value != client_kwargs.get(key)
-            }
-            if "use_ssl" not in client_kwargs.keys():
-                init_kwargs["use_ssl"] = self.use_ssl
-            config_kwargs = self._prepare_config_kwargs()
-            if self.anon:
-                from botocore import UNSIGNED
-
-                drop_keys = {
-                    "aws_access_key_id",
-                    "aws_secret_access_key",
-                    "aws_session_token",
-                }
-                init_kwargs = {
-                    key: value
-                    for key, value in init_kwargs.items()
-                    if key not in drop_keys
-                }
-                client_kwargs = {
-                    key: value
-                    for key, value in client_kwargs.items()
-                    if key not in drop_keys
-                }
-                config_kwargs["signature_version"] = UNSIGNED
-
-            conf = AioConfig(**config_kwargs)
             if self.session is None or refresh:
                 self.session = aiobotocore.session.AioSession(**self.kwargs)
 

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -599,7 +599,8 @@ class S3FileSystem(AsyncFileSystem):
         if self._s3 is not None and not refresh:
             hsess = getattr(getattr(self._s3, "_endpoint", None), "http_session", None)
             if hsess is not None:
-                if all(_.closed for _ in hsess._sessions.values()):
+                sessions = hsess._sessions  # None after __aexit__ in newer aiobotocore
+                if sessions is not None and all(_.closed for _ in sessions.values()):
                     refresh = True
             if not refresh:
                 return self._s3
@@ -693,23 +694,6 @@ class S3FileSystem(AsyncFileSystem):
     _connect = set_session
 
     connect = sync_wrapper(set_session)
-
-    async def _close(self):
-        """Close the underlying S3 client and release all aiohttp sessions."""
-        finalizer = getattr(self, "_finalizer", None)
-        if finalizer is not None:
-            finalizer.detach()
-            self._finalizer = None
-        creator = getattr(self, "_s3creator", None)
-        if creator is not None:
-            try:
-                await creator.__aexit__(None, None, None)
-            except Exception:
-                pass
-            self._s3creator = None
-            self._s3 = None
-
-    close = sync_wrapper(_close)
 
     @staticmethod
     def close_session(loop, s3):

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -667,17 +667,49 @@ class S3FileSystem(AsyncFileSystem):
             )
             self._s3 = await s3creator.__aenter__()
 
+        # Close the stale _s3creator before replacing it.  The old cache holds
+        # aiobotocore ClientSessions that are garbage-collected without an
+        # explicit close(), causing aiohttp "Unclosed client session" warnings.
+        # See: https://github.com/aio-libs/aiobotocore/issues/866
+        old_creator = getattr(self, "_s3creator", None)
+        if old_creator is not None:
+            try:
+                await old_creator.__aexit__(None, None, None)
+            except Exception:
+                pass
         self._s3creator = s3creator
         # the following actually closes the aiohttp connection; use of privates
         # might break in the future, would cause exception at gc time
         if not self.asynchronous:
-            weakref.finalize(self, self.close_session, self.loop, self._s3creator)
+            old_finalizer = getattr(self, "_finalizer", None)
+            if old_finalizer is not None:
+                old_finalizer.detach()
+            self._finalizer = weakref.finalize(
+                self, self.close_session, self.loop, self._s3creator
+            )
         self._kwargs_helper = ParamKwargsHelper(self._s3)
         return self._s3
 
     _connect = set_session
 
     connect = sync_wrapper(set_session)
+
+    async def _close(self):
+        """Close the underlying S3 client and release all aiohttp sessions."""
+        finalizer = getattr(self, "_finalizer", None)
+        if finalizer is not None:
+            finalizer.detach()
+            self._finalizer = None
+        creator = getattr(self, "_s3creator", None)
+        if creator is not None:
+            try:
+                await creator.__aexit__(None, None, None)
+            except Exception:
+                pass
+            self._s3creator = None
+            self._s3 = None
+
+    close = sync_wrapper(_close)
 
     @staticmethod
     def close_session(loop, s3):

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -425,6 +425,7 @@ class S3FileSystem(AsyncFileSystem):
         self.use_ssl = use_ssl
         self.cache_regions = cache_regions
         self._s3 = None
+        self._setup_lock = asyncio.Lock()
         self.session = session
         self.fixed_upload_size = fixed_upload_size
         self.local_expiry_check = local_expiry_check
@@ -600,9 +601,11 @@ class S3FileSystem(AsyncFileSystem):
             hsess = getattr(getattr(self._s3, "_endpoint", None), "http_session", None)
             if hsess is not None:
                 sessions = hsess._sessions  # None after __aexit__ in newer aiobotocore
-                # Only refresh when sessions exist AND all are server-closed.
-                # An empty dict means no requests have been sent yet — not stale.
-                if sessions is not None and sessions and all(_.closed for _ in sessions.values()):
+                # Treat sessions=None (aiobotocore 3.x post-close) and all
+                # server-closed sessions as stale.  Empty dict = not yet used.
+                if sessions is None or (
+                    sessions and all(_.closed for _ in sessions.values())
+                ):
                     refresh = True
             if not refresh:
                 return self._s3
@@ -612,11 +615,7 @@ class S3FileSystem(AsyncFileSystem):
         # try to build their own creator.  Without this lock every concurrent
         # task would create a separate creator and then Fix 1 (close stale
         # creator) would tear down a creator that a sibling task is still using,
-        # causing ``_sessions = None`` mid-request.  asyncio.Lock is
-        # event-loop–aware; creating it between two non-await lines is atomic
-        # so there is no race on the hasattr check.
-        if not hasattr(self, "_setup_lock"):
-            self._setup_lock = asyncio.Lock()
+        # causing ``_sessions = None`` mid-request.
         async with self._setup_lock:
             # Re-check under the lock: a concurrent task may have set up the
             # session while we were waiting.
@@ -649,7 +648,9 @@ class S3FileSystem(AsyncFileSystem):
                     "aws_session_token",
                 }
                 init_kwargs = {
-                    key: value for key, value in init_kwargs.items() if key not in drop_keys
+                    key: value
+                    for key, value in init_kwargs.items()
+                    if key not in drop_keys
                 }
                 client_kwargs = {
                     key: value

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -3189,6 +3189,53 @@ def test_session_close():
     asyncio.run(run_program(False))
 
 
+def test_stale_creator_closed_on_refresh(s3):
+    """Old _s3creator must have __aexit__ called when set_session refreshes.
+
+    Without the fix, the stale aiobotocore ClientSession held by the old
+    _s3creator is garbage-collected without explicit close(), producing
+    aiohttp 'Unclosed client session' warnings at process exit.
+    """
+
+    async def run():
+        await s3.set_session()
+        assert s3._s3creator is not None
+
+        # Replace the real creator with a spy that records whether __aexit__
+        # is called.  The real client is already in s3._s3 so this is safe.
+        class _SpyCreator:
+            exited = False
+
+            async def __aexit__(self, *args):
+                _SpyCreator.exited = True
+
+        s3._s3creator = _SpyCreator()
+        await s3.set_session(refresh=True)
+
+        assert _SpyCreator.exited, (
+            "Old _s3creator.__aexit__ was not called during session refresh; "
+            "aiohttp sessions will leak"
+        )
+
+    asyncio.run(run())
+
+
+def test_close_releases_client(s3):
+    """Calling close() must release the S3 client and creator immediately."""
+
+    async def run():
+        await s3.set_session()
+        assert s3._s3creator is not None
+        assert s3._s3 is not None
+
+        await s3._close()
+
+        assert s3._s3creator is None, "_close() should set _s3creator to None"
+        assert s3._s3 is None, "_close() should set _s3 to None"
+
+    asyncio.run(run())
+
+
 def test_rm_recursive_prfix(s3):
     prefix = "logs/"  # must end with "/"
 

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -3220,21 +3220,6 @@ def test_stale_creator_closed_on_refresh(s3):
     asyncio.run(run())
 
 
-def test_close_releases_client(s3):
-    """Calling close() must release the S3 client and creator immediately."""
-
-    async def run():
-        await s3.set_session()
-        assert s3._s3creator is not None
-        assert s3._s3 is not None
-
-        await s3._close()
-
-        assert s3._s3creator is None, "_close() should set _s3creator to None"
-        assert s3._s3 is None, "_close() should set _s3 to None"
-
-    asyncio.run(run())
-
 
 def test_rm_recursive_prfix(s3):
     prefix = "logs/"  # must end with "/"


### PR DESCRIPTION
## Problem

Three related issues in `S3FileSystem.set_session()` that together cause `aiohttp` `Unclosed client session` / `Unclosed connector` warnings when the server closes connections mid-session:

1. **Stale `_s3creator` is silently abandoned on refresh.** When `set_session(refresh=True)` replaces `self._s3creator` with a new `S3BucketRegionCache`, the old cache is never closed. It holds aiobotocore-created `aiohttp.ClientSession` objects (1 general + up to N regional). GC'd without an explicit `close()` → aiohttp emits warnings.

2. **Vacuous-truth refresh on empty `_sessions`.** `all(_.closed for _ in [])` is always `True`, so a freshly-entered `AIOHTTPSession` with `_sessions = {}` (no requests sent yet) incorrectly triggers `refresh=True`. This causes the next issue to fire spuriously.

3. **Concurrent callers (e.g. `asyncio.gather`) each create their own creator.** When `self._s3 is None`, multiple concurrent coroutines all fall through to the setup path. Without serialization, Task B's Fix 1 (close stale creator) tears down Task A's creator while Task A is mid-request — setting `_sessions = None` on an active `AIOHTTPSession`, producing:
   ```
   AttributeError: 'NoneType' object has no attribute 'get'
   ```
   at `aiobotocore/httpsession.py`.

The stale-check also needs to guard against newer aiobotocore setting `_sessions = None` (rather than `{}`) after `__aexit__`.

## Changes

**`s3fs/core.py`**

- **Fix 1 — Close stale `_s3creator` on refresh**: Before `self._s3creator = s3creator`, call `await old_creator.__aexit__(None, None, None)` so all regional aiobotocore clients and their aiohttp sessions are closed cleanly.

- **Fix 2 — Guard stale-session check**: Change the stale-session refresh condition to:
  ```python
  if sessions is not None and sessions and all(_.closed for _ in sessions.values()):
      refresh = True
  ```
  - `sessions is not None` — newer aiobotocore sets `_sessions = None` after `__aexit__`; treat `None` as "not stale, just closed"
  - `sessions` (non-empty) — an empty dict means no requests have been sent yet; not stale

- **Fix 3 — Serialize creator setup under `asyncio.Lock`**: Wrap the entire creator-setup path in `async with self._setup_lock`. Concurrent tasks wait at the lock, then re-check `self._s3 is not None` and reuse the already-created session rather than creating their own. This makes Fix 1 safe: the old creator is only closed once, by the task that wins the lock, before any new sessions are open.

**`s3fs/tests/test_s3fs.py`**

- `test_stale_creator_closed_on_refresh` — patches `__aexit__` on the old creator and asserts it was called during `set_session(refresh=True)`

**`docs/source/changelog.rst`** — Unreleased section added.

## Motivation

Discovered while integrating zarr v3's `FsspecStore.close()` (zarr-developers/zarr-python#4003). zarr's `asyncio.gather` fires 4 concurrent `FsspecStore.get()` calls on the same `S3FileSystem` instance, triggering issue 3. Issues 1 and 2 produce residual unclosed-session warnings once the render completes.

Related: aiobotocore/aiobotocore#866

## Test

All existing tests pass. New test confirms `__aexit__` is called on the old creator during refresh.