### PR TITLE
Wrap potential error in the _cat_file_concurrent 

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -1359,7 +1359,7 @@ class S3FileSystem(AsyncFileSystem):
                 **version_id_kw(version_id),
                 **kw,
             )
-            data = await resp["Body"].read()
+            data = await _error_wrapper(resp["Body"].read, retries=self.retries)
             resp["Body"].close()
             return start, data
 


### PR DESCRIPTION
I'm using `zarr `with s3 and `s3fs` store backend. I have a encountered problems with `_cat_file_concurrent` method, with large load it can throw an `AioTimeoutError` not respecting s3fs retries. Adding a missing `_error_wrapper` in the place of failure. 